### PR TITLE
Fix emoji page indicator background amoled

### DIFF
--- a/app/src/main/res/values/themes-lxx-dark-amoled.xml
+++ b/app/src/main/res/values/themes-lxx-dark-amoled.xml
@@ -61,7 +61,7 @@
         name="EmojiPalettesView.LXX_Dark_Amoled"
         parent="EmojiPalettesView.LXX_Dark"
     >
-        <item name="categoryPageIndicatorBackground">@android:color/transparent</item>
+        <item name="categoryPageIndicatorBackground">@color/background_amoled_dark</item>
         <item name="android:background">@color/background_amoled_black</item>
         <item name="keyBackground">@drawable/btn_keyboard_key_lxx_dark_amoled</item>
     </style>


### PR DESCRIPTION
This PR fixes issue #412 about emoji page indicator background in amoled mode.
The color used is the same as the suggestion strip.

 Tested on Huawei phone with Android 10.

- Before :
![Screenshot_emoji_amoled_before](https://github.com/Helium314/openboard/assets/139015663/9abe065c-cfea-44fb-adf6-28a0aaac090a)

- After :
![Screenshot_emoji_amoled_after](https://github.com/Helium314/openboard/assets/139015663/866a4e16-cacf-41d8-9dfb-e1a24d55cd50)
