### PR TITLE
Split number row

### DIFF
--- a/app/src/main/res/xml/row_optional_number_row.xml
+++ b/app/src/main/res/xml/row_optional_number_row.xml
@@ -5,6 +5,22 @@
     <switch>
         <case
             latin:numberRowEnabled="true"
+            latin:isSplitLayout="true"
+            >
+            <Row
+                latin:keyWidth="8%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1_left1" />
+                <Spacer
+                    latin:keyWidth="20.0%p" />
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1_right1" />
+            </Row>
+        </case>
+        <case
+            latin:numberRowEnabled="true"
+            latin:isSplitLayout="false"
             >
             <Row
                 latin:keyWidth="10%p"

--- a/app/src/main/res/xml/rowkeys_symbols1_left1.xml
+++ b/app/src/main/res/xml/rowkeys_symbols1_left1.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <Key
+        latin:keySpec="!text/keyspec_symbols_1"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_1"
+        latin:moreKeys="!text/morekeys_symbols_1" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_2"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_2"
+        latin:moreKeys="!text/morekeys_symbols_2" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_3"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_3"
+        latin:moreKeys="!text/morekeys_symbols_3" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_4"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_4"
+        latin:moreKeys="!text/morekeys_symbols_4" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_5"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_5"
+        latin:moreKeys="!text/morekeys_symbols_5" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_symbols1_right1.xml
+++ b/app/src/main/res/xml/rowkeys_symbols1_right1.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <Key
+        latin:keySpec="!text/keyspec_symbols_6"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_6"
+        latin:moreKeys="!text/morekeys_symbols_6" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_7"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_7"
+        latin:moreKeys="!text/morekeys_symbols_7" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_8"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_8"
+        latin:moreKeys="!text/morekeys_symbols_8" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_9"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_9"
+        latin:moreKeys="!text/morekeys_symbols_9" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_0"
+        latin:additionalMoreKeys="!text/additional_morekeys_symbols_0"
+        latin:moreKeys="!text/morekeys_symbols_0" />
+</merge>


### PR DESCRIPTION
**Improvement - No existing issue**

When `Enable split keyboard` is toggle on, this commit allows the number row to be split like the letter rows.

Tested on Samsung tablet with Android 13.

- Before:
![Split_number_row_before1](https://github.com/Helium314/openboard/assets/139015663/161360a3-11b4-4241-baca-a3a3c2742db2)

- After:
![Split_number_row_after1](https://github.com/Helium314/openboard/assets/139015663/6f395617-deb4-48c3-ae54-a2fd988d4cec)


