### PR TITLE
Fix enter key in split mode for AZERTY

### DIFF
--- a/app/src/main/res/xml-sw600dp-land/rows_azerty.xml
+++ b/app/src/main/res/xml-sw600dp-land/rows_azerty.xml
@@ -67,7 +67,7 @@
                     latin:keyXPos="4.0%p"
                     latin:keyWidth="7.0%p" />
                 <Spacer
-                    latin:keyWidth="23.0%p" />
+                    latin:keyWidth="16.0%p" />
                 <include
                     latin:keyboardLayout="@xml/rowkeys_azerty2_right5"
                     latin:keyWidth="7.0%p" />


### PR DESCRIPTION
This PR fixes the 2nd line space when the keyboard is splited for AZERTY. Only tablets are affected.
Indeed, enter key is hidden.

- Before
![Before1](https://github.com/Helium314/openboard/assets/139015663/db191840-2c74-40be-89dc-f60da3812c7a)

- After
![After1](https://github.com/Helium314/openboard/assets/139015663/9b4a5324-d621-4c74-875b-59bdddebfc05)

Tested on Samsung Tablet with Android 13.