### PR TITLE
Fix_alignment_Shift/Delete_with_Symbol/Enter_keys

### DIFF
--- a/app/src/main/res/xml/rows_azerty.xml
+++ b/app/src/main/res/xml/rows_azerty.xml
@@ -42,14 +42,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_azerty3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_bengali_unijoy.xml
+++ b/app/src/main/res/xml/rows_bengali_unijoy.xml
@@ -43,14 +43,12 @@
         >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_bengali_unijoy3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_bepo.xml
+++ b/app/src/main/res/xml/rows_bepo.xml
@@ -37,14 +37,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_bepo3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_colemak.xml
+++ b/app/src/main/res/xml/rows_colemak.xml
@@ -42,14 +42,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_colemak3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_colemak_dh.xml
+++ b/app/src/main/res/xml/rows_colemak_dh.xml
@@ -42,14 +42,12 @@
         >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_colemak_dh3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_dvorak.xml
+++ b/app/src/main/res/xml/rows_dvorak.xml
@@ -42,14 +42,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_dvorak3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <!-- Dvorak layout shares almost the same row with Qwerty layout.
          The difference is defined in xml/row_qwerty4.xml. -->

--- a/app/src/main/res/xml/rows_georgian.xml
+++ b/app/src/main/res/xml/rows_georgian.xml
@@ -43,14 +43,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_georgian3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_german.xml
+++ b/app/src/main/res/xml/rows_german.xml
@@ -42,15 +42,13 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_german3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
             latin:keyXPos="-15%p"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_greek.xml
+++ b/app/src/main/res/xml/rows_greek.xml
@@ -43,14 +43,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_greek3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_halmak.xml
+++ b/app/src/main/res/xml/rows_halmak.xml
@@ -42,14 +42,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_halmak3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_halmak4" />

--- a/app/src/main/res/xml/rows_nepali_romanized.xml
+++ b/app/src/main/res/xml/rows_nepali_romanized.xml
@@ -40,13 +40,11 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include latin:keyboardLayout="@xml/rowkeys_nepali_romanized3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include latin:keyboardLayout="@xml/row_qwerty4" />
 </merge>

--- a/app/src/main/res/xml/rows_nordic.xml
+++ b/app/src/main/res/xml/rows_nordic.xml
@@ -42,8 +42,7 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <Spacer
             latin:keyWidth="2.8%p" />
         <include
@@ -51,8 +50,7 @@
         <Key
             latin:keyStyle="deleteKeyStyle"
             latin:keyXPos="-15%p"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_qwerty.xml
+++ b/app/src/main/res/xml/rows_qwerty.xml
@@ -43,14 +43,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_qwerty3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_qwertz.xml
+++ b/app/src/main/res/xml/rows_qwertz.xml
@@ -43,14 +43,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_qwertz3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
    <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_spanish.xml
+++ b/app/src/main/res/xml/rows_spanish.xml
@@ -42,14 +42,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_qwerty3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_swiss.xml
+++ b/app/src/main/res/xml/rows_swiss.xml
@@ -42,8 +42,7 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <Spacer
             latin:keyWidth="2.8%p" />
         <include
@@ -51,8 +50,7 @@
         <Key
             latin:keyStyle="deleteKeyStyle"
             latin:keyXPos="-15%p"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include
         latin:keyboardLayout="@xml/row_qwerty4" />

--- a/app/src/main/res/xml/rows_symbols.xml
+++ b/app/src/main/res/xml/rows_symbols.xml
@@ -55,14 +55,12 @@
     >
         <Key
             latin:keyStyle="toMoreSymbolKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_symbols3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <Row
         latin:keyWidth="10%p"

--- a/app/src/main/res/xml/rows_symbols_shift.xml
+++ b/app/src/main/res/xml/rows_symbols_shift.xml
@@ -45,14 +45,12 @@
     >
         <Key
             latin:keyStyle="backFromMoreSymbolKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_symbols_shift3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <Row
         latin:keyWidth="10%p"

--- a/app/src/main/res/xml/rows_turkish.xml
+++ b/app/src/main/res/xml/rows_turkish.xml
@@ -20,14 +20,12 @@
     >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_turkish3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <include latin:keyboardLayout="@xml/row_qwerty4" />
 </merge>

--- a/app/src/main/res/xml/rows_uzbek.xml
+++ b/app/src/main/res/xml/rows_uzbek.xml
@@ -31,15 +31,13 @@
     <Row latin:keyWidth="9.2%p" >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <Spacer latin:keyWidth="2.8%p" />
         <include latin:keyboardLayout="@xml/rowkeys_qwerty3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
             latin:keyWidth="fillRight"
-            latin:keyXPos="-15%p"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyXPos="-15%p" />
     </Row>
     <include latin:keyboardLayout="@xml/row_qwerty4" />
 </merge>

--- a/app/src/main/res/xml/rows_workman.xml
+++ b/app/src/main/res/xml/rows_workman.xml
@@ -42,14 +42,12 @@
         >
         <Key
             latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyWidth="15%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_workman3" />
         <Key
             latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight"
-            latin:visualInsetsLeft="1%p" />
+            latin:keyWidth="fillRight" />
     </Row>
     <!-- Fourth row -->
     <include


### PR DESCRIPTION
This PR fixes the alignment between the Shift/Delete keys and the Symbols/Enter keys.

This misalignment is caused by 2 values:

- `latin:visualInsetsRight="1%p"`
- `latin:visualInsetsLeft="1%p"`

Removing them fixes the bug feeling.

- Picture Before // Picture After

<img alt="before" width="200" src="https://user-images.githubusercontent.com/139015663/257016910-7cb5de68-e924-4f84-8e18-83ba20fbf999.jpg"> <img alt="after" width="200" src="https://user-images.githubusercontent.com/139015663/257017048-a3dd9ea8-a9bb-4833-a941-061267b0c0f0.jpg">

Tested on Huawei Phone with Android 10.
Tested with these keyboards:
- AZERTY // Bengali // QWERTY //QWERTZ // Dvorak // Colemak // Colemak dh // Workman // Greek // Spain // Turkish // Nepal // etc