### PR TITLE
Resolved "Todo" in themes-lxx-base.xml and themes-lxx-base-border.xml

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
@@ -77,6 +77,8 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
     public static final int THEME_ID_LXX_AUTO_BORDER = 8;
     public static final int THEME_ID_LXX_CUSTOM = 11;
     public static final int THEME_ID_LXX_CUSTOM_BORDER = 12;
+    public static final int THEME_ID_LXX_BASE = 14;
+    public static final int THEME_ID_LXX_BASE_BORDER = 15;
     public static final int DEFAULT_THEME_ID = THEME_ID_LXX_DARK_BORDER;
 
     private static KeyboardTheme[] AVAILABLE_KEYBOARD_THEMES;
@@ -122,6 +124,12 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
         new KeyboardTheme(THEME_ID_KLP_CUSTOM, "KLPCustom", R.style.KeyboardTheme_KLP,
                 // This has never been selected as default theme.
                 VERSION_CODES.BASE),
+        new KeyboardTheme(THEME_ID_LXX_BASE, "LXXBase", R.style.KeyboardTheme_LXX_Base,
+                // This has never been selected as default theme.
+                VERSION_CODES.LOLLIPOP),
+        new KeyboardTheme(THEME_ID_LXX_BASE_BORDER, "LXXBaseBorder", R.style.KeyboardTheme_LXX_Base_Border,
+                // This has never been selected as default theme.
+                VERSION_CODES.LOLLIPOP),
     };
 
     static {

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -248,6 +248,8 @@
             <enum name="LXXCustom" value="11" />
             <enum name="LXXCustomBorder" value="12" />
             <enum name="KLPCustom" value="13" />
+            <enum name="LXXBase" value="14" />
+            <enum name="LXXBaseBorder" value="15" />
         </attr>
         <!-- Touch position correction -->
         <attr name="touchPositionCorrectionData" format="reference" />

--- a/app/src/main/res/values/themes-lxx-base-border.xml
+++ b/app/src/main/res/values/themes-lxx-base-border.xml
@@ -3,7 +3,7 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="KeyboardTheme.LXX_Base_Border"
            parent="KeyboardTheme.LXX_Base">
-        <item name="keyboardStyle">@style/Keyboard.LXX_Base_Border</item> <!-- todo: see comment for lxx-base, though here only the action key popup in search field is weird -->
+        <item name="keyboardStyle">@style/Keyboard.LXX_Base_Border</item>
         <item name="keyboardViewStyle">@style/KeyboardView.LXX_Base_Border</item>
         <item name="mainKeyboardViewStyle">@style/MainKeyboardView.LXX_Base_Border</item>
         <item name="emojiPalettesViewStyle">@style/EmojiPalettesView.LXX_Base_Border</item>

--- a/app/src/main/res/values/themes-lxx-base-border.xml
+++ b/app/src/main/res/values/themes-lxx-base-border.xml
@@ -3,7 +3,7 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="KeyboardTheme.LXX_Base_Border"
            parent="KeyboardTheme.LXX_Base">
-        <item name="keyboardStyle">@style/Keyboard.LXX_Light_Border</item> <!-- todo: see comment for lxx-base, though here only the action key popup in search field is weird -->
+        <item name="keyboardStyle">@style/Keyboard.LXX_Base_Border</item> <!-- todo: see comment for lxx-base, though here only the action key popup in search field is weird -->
         <item name="keyboardViewStyle">@style/KeyboardView.LXX_Base_Border</item>
         <item name="mainKeyboardViewStyle">@style/MainKeyboardView.LXX_Base_Border</item>
         <item name="emojiPalettesViewStyle">@style/EmojiPalettesView.LXX_Base_Border</item>
@@ -15,6 +15,8 @@
         name="Keyboard.LXX_Base_Border"
         parent="Keyboard"
     >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXBaseBorder</item>
     </style>
     <style
         name="KeyboardView.LXX_Base_Border"

--- a/app/src/main/res/values/themes-lxx-base.xml
+++ b/app/src/main/res/values/themes-lxx-base.xml
@@ -3,7 +3,7 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="KeyboardTheme.LXX_Base" parent="KeyboardIcons.LXX_Light">
         <item name="inputViewStyle">@style/InputView.LXX</item>
-        <item name="keyboardStyle">@style/Keyboard.LXX_Base</item> <!-- todo: when using Keyboard.LXX_Base, the action key doesn't keep aspect ratio, and sometimes action more keys popup looks bad... wtf? -->
+        <item name="keyboardStyle">@style/Keyboard.LXX_Base</item>
         <item name="keyboardViewStyle">@style/KeyboardView.LXX_Base</item>
         <item name="mainKeyboardViewStyle">@style/MainKeyboardView.LXX_Base</item>
         <item name="emojiPalettesViewStyle">@style/EmojiPalettesView.LXX_Base</item>

--- a/app/src/main/res/values/themes-lxx-base.xml
+++ b/app/src/main/res/values/themes-lxx-base.xml
@@ -3,7 +3,7 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="KeyboardTheme.LXX_Base" parent="KeyboardIcons.LXX_Light">
         <item name="inputViewStyle">@style/InputView.LXX</item>
-        <item name="keyboardStyle">@style/Keyboard.LXX_Light</item> <!-- todo: when using Keyboard.LXX_Base, the action key doesn't keep aspect ratio, and sometimes action more keys popup looks bad... wtf? -->
+        <item name="keyboardStyle">@style/Keyboard.LXX_Base</item> <!-- todo: when using Keyboard.LXX_Base, the action key doesn't keep aspect ratio, and sometimes action more keys popup looks bad... wtf? -->
         <item name="keyboardViewStyle">@style/KeyboardView.LXX_Base</item>
         <item name="mainKeyboardViewStyle">@style/MainKeyboardView.LXX_Base</item>
         <item name="emojiPalettesViewStyle">@style/EmojiPalettesView.LXX_Base</item>
@@ -18,6 +18,8 @@
         name="Keyboard.LXX_Base"
         parent="Keyboard"
     >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXBase</item>
     </style>
     <style
         name="KeyboardView.LXX_Base"

--- a/app/src/main/res/xml-sw600dp/key_styles_enter.xml
+++ b/app/src/main/res/xml-sw600dp/key_styles_enter.xml
@@ -81,7 +81,7 @@
     </switch>
     <!-- Enter key style -->
     <switch>
-        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder">
+        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder|LXXBaseBorder">
             <key-style
                 latin:styleName="defaultEnterKeyStyle"
                 latin:keySpec="!icon/enter_key|!code/key_enter"

--- a/app/src/main/res/xml/key_styles_common.xml
+++ b/app/src/main/res/xml/key_styles_common.xml
@@ -78,7 +78,7 @@
         latin:backgroundType="functional" />
     <!-- emojiKeyStyle must be defined before including @xml/key_syles_enter. -->
     <switch>
-        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder">
+        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder|LXXBaseBorder">
             <key-style
                 latin:styleName="emojiKeyStyle"
                 latin:keySpec="!icon/emoji_normal_key|!code/key_emoji"

--- a/app/src/main/res/xml/key_styles_enter.xml
+++ b/app/src/main/res/xml/key_styles_enter.xml
@@ -213,7 +213,7 @@
     </switch>
     <!-- Enter key style -->
     <switch>
-        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder">
+        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder|LXXBaseBorder">
             <key-style
                 latin:styleName="defaultEnterKeyStyle"
                 latin:keySpec="!icon/enter_key|!code/key_enter"


### PR DESCRIPTION
This PR solves the two "**_todo_**" in the themes-lxx-base.xml and themes-lxx-base-border.xml files:

https://github.com/Helium314/openboard/blob/4c871bea54ed4400475c72e313e41f8a2a151e5f/app/src/main/res/values/themes-lxx-base.xml#L6

https://github.com/Helium314/openboard/blob/4c871bea54ed4400475c72e313e41f8a2a151e5f/app/src/main/res/values/themes-lxx-base-border.xml#L6

_Tested on Samsung Tablet with Android 13 and on Huawei phone with Android 10._