### PR TITLE
Fixed missing rounded popups and rounded selector for base themes

### DIFF
--- a/app/src/main/res/drawable/btn_keyboard_key_popup_lxx_base.xml
+++ b/app/src/main/res/drawable/btn_keyboard_key_popup_lxx_base.xml
@@ -1,24 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2014 The Android Open Source Project
-
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
--->
-
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true" >
         <shape android:shape="rectangle">
             <solid android:color="@color/key_background_normal_lxx_base_border" />
+            <corners android:radius="3dp" />
         </shape>
     </item>
-    <item android:drawable="@android:color/white" />
+    <item>
+        <shape android:shape="rectangle" >
+            <solid android:color="@android:color/white" />
+            <corners android:radius="3dp" />
+        </shape>
+    </item>
 </selector>


### PR DESCRIPTION
@RHJihan found that the corners of popups were no longer rounded.

<img width=300 src="https://user-images.githubusercontent.com/31377578/258087759-f3566686-4dac-4c9e-aab5-0395fb0cdf4a.png">

Now, this is fixed for border and no-border themes:

<img width=400 src="https://user-images.githubusercontent.com/139015663/258569991-7de85a56-4f2b-4c98-8294-663a60ce375b.png">

_Tested by @RHJihan and me._