### PR TITLE
Added HSL properties to lighten or darken colors

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.java
@@ -163,7 +163,7 @@ public class Colors {
     public static int brighten(@ColorInt int color) {
         float[] hsl = new float[3];
         ColorUtils.colorToHSL(color, hsl);
-        hsl[2] += 0.1f;
+        hsl[2] += 0.05f;
         return ColorUtils.HSLToColor(hsl);
     }
 
@@ -171,7 +171,7 @@ public class Colors {
     public static int darken(@ColorInt int color) {
         float[] hsl = new float[3];
         ColorUtils.colorToHSL(color, hsl);
-        hsl[2] -= 0.1f;
+        hsl[2] -= 0.05f;
         return ColorUtils.HSLToColor(hsl);
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.java
@@ -7,6 +7,8 @@ import android.graphics.ColorFilter;
 
 import androidx.core.graphics.BlendModeColorFilterCompat;
 import androidx.core.graphics.BlendModeCompat;
+import androidx.annotation.ColorInt;
+import androidx.core.graphics.ColorUtils;
 
 import org.dslul.openboard.inputmethod.keyboard.KeyboardTheme;
 
@@ -142,16 +144,6 @@ public class Colors {
         return getBrightnessSquared(color) < 50*50;
     }
 
-    private static int brighten(final int color) {
-        // brighten is stronger, because often the drawables get darker when pressed
-        // todo (maybe): remove the darker pressed colors to have more consistent behavior?
-        return blendARGB(color, Color.WHITE, 0.14f);
-    }
-
-    private static int darken(final int color) {
-        return blendARGB(color, Color.BLACK, 0.11f);
-    }
-
     public static int brightenOrDarken(final int color, final boolean preferDarken) {
         if (preferDarken) {
             if (isDarkColor(color)) return brighten(color);
@@ -160,21 +152,27 @@ public class Colors {
         else return brighten(color);
     }
 
-    // taken from androidx ColorUtils, modified to keep alpha of color1
-    private static int blendARGB(int color1, int color2, float ratio) {
-        final float inverseRatio = 1 - ratio;
-        float a = Color.alpha(color1);
-        float r = Color.red(color1) * inverseRatio + Color.red(color2) * ratio;
-        float g = Color.green(color1) * inverseRatio + Color.green(color2) * ratio;
-        float b = Color.blue(color1) * inverseRatio + Color.blue(color2) * ratio;
-        return Color.argb((int) a, (int) r, (int) g, (int) b);
-    }
-
     private static int getBrightnessSquared(final int color) {
         // See http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
         int[] rgb = {Color.red(color), Color.green(color), Color.blue(color)};
         // we are only interested whether brightness is greater, so no need for sqrt
         return (int) (rgb[0] * rgb[0] * .241 + rgb[1] * rgb[1] * .691 + rgb[2] * rgb[2] * .068);
+    }
+
+    @ColorInt
+    public static int brighten(@ColorInt int color) {
+        float[] hsl = new float[3];
+        ColorUtils.colorToHSL(color, hsl);
+        hsl[2] += 0.1f;
+        return ColorUtils.HSLToColor(hsl);
+    }
+
+    @ColorInt
+    public static int darken(@ColorInt int color) {
+        float[] hsl = new float[3];
+        ColorUtils.colorToHSL(color, hsl);
+        hsl[2] -= 0.1f;
+        return ColorUtils.HSLToColor(hsl);
     }
 
 }


### PR DESCRIPTION
This PR is created to implement HSL properties to colors.

Now, there is no more gray tint in the popup background and in the selection background of popup.
The colors are therefore more consistent with the color themes.

Another important thing: the default themes are not impacted and if you see a difference, it will only be very minor.

By using the HSL properties, the 2 functions below no longer use white or black to adjust the hue but use the color associated with the keyboard background and a factor to either lighten or darken the color.

https://github.com/Helium314/openboard/blob/9cc996c296c727f33a2931fb7b5b02083ea43b8c/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.java#L145-L153

Screenshots below: _left = without HSL // **right = with HSL**_

- <img width=300 src="https://user-images.githubusercontent.com/139015663/258575583-78a8dc7a-9b02-4d25-8d20-10f673bb9d61.png">

- <img width=300 src="https://user-images.githubusercontent.com/139015663/258575622-8410a485-8283-4202-96fd-1e03faa7c76c.png">

- <img width=300 src="https://user-images.githubusercontent.com/139015663/258581011-66e5c259-ca84-4e6c-999f-6645c57123a8.png">


_Tested on Samsung Tablet with Android 13 and on Huawei phone with Android 10._
