### PR TITLE
Improved keyboard display for tablet

### DIFF
--- a/app/src/main/res/values-sw768dp-land/config.xml
+++ b/app/src/main/res/values-sw768dp-land/config.xml
@@ -22,11 +22,11 @@
 <resources>
     <!-- Preferable keyboard height in absolute scale: 58.0mm -->
     <!-- This config_default_keyboard_height value should match with keyboard-heights.xml -->
-    <dimen name="config_default_keyboard_height">365.4dp</dimen>
+    <dimen name="config_default_keyboard_height">270.4dp</dimen>
     <fraction name="config_min_keyboard_height">35%p</fraction>
 
     <fraction name="config_keyboard_top_padding_holo">1.896%p</fraction>
-    <fraction name="config_keyboard_bottom_padding_holo">0.0%p</fraction>
+    <fraction name="config_keyboard_bottom_padding_holo">3.690%p</fraction>
     <fraction name="config_key_vertical_gap_holo">3.690%p</fraction>
     <fraction name="config_key_horizontal_gap_holo">1.030%p</fraction>
 
@@ -38,20 +38,20 @@
     <fraction name="config_key_large_letter_ratio_lxx">60%</fraction>
     <fraction name="config_key_label_ratio_holo">28%</fraction>
     <fraction name="config_key_label_ratio_lxx">32%</fraction>
-    <fraction name="config_key_hint_letter_ratio_holo">23%</fraction>
-    <fraction name="config_key_hint_letter_ratio_lxx">23%</fraction>
+    <fraction name="config_key_hint_letter_ratio_holo">30%</fraction>
+    <fraction name="config_key_hint_letter_ratio_lxx">30%</fraction>
     <fraction name="config_key_hint_label_ratio_holo">28%</fraction>
     <fraction name="config_key_hint_label_ratio_lxx">20%</fraction>
     <fraction name="config_key_shifted_letter_hint_ratio_holo">24%</fraction>
     <fraction name="config_key_shifted_letter_hint_ratio_lxx">24%</fraction>
-    <fraction name="config_language_on_spacebar_text_ratio">24.00%</fraction>
+    <fraction name="config_language_on_spacebar_text_ratio">30.00%</fraction>
 
     <!-- For 5-row keyboard -->
     <fraction name="config_key_vertical_gap_5row">2.65%p</fraction>
     <fraction name="config_key_letter_ratio_5row">53%</fraction>
     <fraction name="config_key_shifted_letter_hint_ratio_5row">30%</fraction>
 
-    <dimen name="config_suggestions_strip_height">44dp</dimen>
+    <dimen name="config_suggestions_strip_height">40dp</dimen>
     <dimen name="config_suggestions_strip_horizontal_margin">340dp</dimen>
     <dimen name="config_suggestions_strip_edge_key_width">54dp</dimen>
     <fraction name="config_min_more_suggestions_width">50%</fraction>

--- a/app/src/main/res/values-sw768dp/config.xml
+++ b/app/src/main/res/values-sw768dp/config.xml
@@ -27,7 +27,7 @@
     <fraction name="config_min_keyboard_height">-35.0%p</fraction>
 
     <fraction name="config_keyboard_top_padding_holo">2.335%p</fraction>
-    <fraction name="config_keyboard_bottom_padding_holo">0.0%p</fraction>
+    <fraction name="config_keyboard_bottom_padding_holo">3.312%p</fraction>
     <fraction name="config_key_vertical_gap_holo">3.312%p</fraction>
     <fraction name="config_key_horizontal_gap_holo">1.066%p</fraction>
     <!-- config_more_keys_keyboard_key_height x -0.5 -->
@@ -46,8 +46,8 @@
     <fraction name="config_key_large_letter_ratio_lxx">60%</fraction>
     <fraction name="config_key_label_ratio_holo">28%</fraction>
     <fraction name="config_key_label_ratio_lxx">32%</fraction>
-    <fraction name="config_key_hint_letter_ratio_holo">23%</fraction>
-    <fraction name="config_key_hint_letter_ratio_lxx">23%</fraction>
+    <fraction name="config_key_hint_letter_ratio_holo">25%</fraction>
+    <fraction name="config_key_hint_letter_ratio_lxx">25%</fraction>
     <fraction name="config_key_hint_label_ratio_holo">28%</fraction>
     <fraction name="config_key_hint_label_ratio_lxx">20%</fraction>
     <fraction name="config_key_shifted_letter_hint_ratio_holo">26%</fraction>
@@ -61,7 +61,7 @@
     <fraction name="config_key_letter_ratio_5row">51%</fraction>
     <fraction name="config_key_shifted_letter_hint_ratio_5row">33%</fraction>
 
-    <dimen name="config_suggestions_strip_height">44dp</dimen>
+    <dimen name="config_suggestions_strip_height">40dp</dimen>
     <dimen name="config_suggestions_strip_horizontal_margin">100dp</dimen>
     <dimen name="config_suggestions_strip_edge_key_width">54dp</dimen>
     <dimen name="config_more_suggestions_row_height">44dp</dimen>
@@ -69,7 +69,7 @@
     <fraction name="config_min_more_suggestions_width">90%</fraction>
     <dimen name="config_suggestion_min_width">46dp</dimen>
     <dimen name="config_suggestion_text_horizontal_padding">10dp</dimen>
-    <dimen name="config_suggestion_text_size">22dp</dimen>
+    <dimen name="config_suggestion_text_size">18dp</dimen>
     <dimen name="config_more_suggestions_hint_text_size">33dp</dimen>
 
     <!-- Gesture floating preview text parameters -->


### PR DESCRIPTION
This PR improves openboard display **for tablet users only**.

Indeed, some values are inconsistent as if they had never been tested: either too small or too high.

The only aim of this PR is to make Openboard better on tablets and improve user experience so only relevant values have been modified.

Below, details of changes:

**1.** `<dimen name="config_default_keyboard_height">` → really too high

&emsp;_Picture taken with scale set to 100%:_
&emsp;<img width=400 src="https://user-images.githubusercontent.com/139015663/258594727-dec397b7-82ac-4e2a-8fcc-4bb7c58ea0d4.jpg">

---
**2.** `<fraction name="config_keyboard_bottom_padding_holo">` → For users using gestures on their tablet, there is no space between the bottom of the screen and the space bar. The new value is therefore equal to `<fraction name="config_key_vertical_gap_holo">` to be consistent

&emsp;<img width=400 src="https://user-images.githubusercontent.com/139015663/258594646-e06aa9fb-c647-4715-a473-3d367dd676d0.jpg">

---
**3.** `<fraction name="config_key_hint_letter_ratio_holo">` + 
`<fraction name="config_key_hint_letter_ratio_lxx">` +
`<fraction name="config_language_on_spacebar_text_ratio">` → really too small
`<dimen name="config_suggestions_strip_height">` → too high

&emsp;_Screeshots taken with scale set to 80%:_
&emsp;<img width=400 src="https://user-images.githubusercontent.com/139015663/258597655-abe73e6f-8121-4972-837a-517730378d14.png">

---
**4.** `<dimen name="config_suggestion_text_size">` → too high

&emsp;<img width=400 src="https://user-images.githubusercontent.com/139015663/258595602-eb0ec9a7-5ace-4eb6-bdd3-08d8e8f1b883.png">

---

_Tested on Samsung tablet with Android 13 // Screen 10.5 inches - 1200 x 1920_


