### PR TITLE
Symbols modified on "f" + "m" + "apostrophe" keys

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -253,15 +253,16 @@ public final class KeyboardTextsTable {
         /* 169: 0 */ "double_9qm_lqm",
         /* 170: 0 */ "double_9qm_rqm",
         /* 171: 0 */ "double_rqm_9qm",
-        /* 172: 0 */ "morekeys_single_quote",
-        /* 173: 0 */ "morekeys_double_quote",
-        /* 174: 0 */ "morekeys_tablet_double_quote",
-        /* 175: 0 */ "keyspec_emoji_action_key",
-        /* 176: 0 */ "keyspec_emoji_normal_key",
-        /* 177: 0 */ "keyspec_clipboard_action_key",
-        /* 178: 0 */ "keyspec_clipboard_normal_key",
-        /* 179: 0 */ "keyspec_start_onehanded_mode",
-        /* 180: 0 */ "keyspec_language_switch",
+        /* 172: 0 */ "morekeys_apostrophe",
+        /* 173: 0 */ "morekeys_single_quote",
+        /* 174: 0 */ "morekeys_double_quote",
+        /* 175: 0 */ "morekeys_tablet_double_quote",
+        /* 176: 0 */ "keyspec_emoji_action_key",
+        /* 177: 0 */ "keyspec_emoji_normal_key",
+        /* 178: 0 */ "keyspec_clipboard_action_key",
+        /* 179: 0 */ "keyspec_clipboard_normal_key",
+        /* 180: 0 */ "keyspec_start_onehanded_mode",
+        /* 181: 0 */ "keyspec_language_switch",
     };
 
     private static final String EMPTY = "";
@@ -482,6 +483,7 @@ public final class KeyboardTextsTable {
         /* double_9qm_lqm */ "\u201D,\u201E,\u201C",
         /* double_9qm_rqm */ "\u201C,\u201E,\u201D",
         /* double_rqm_9qm */ "\u201C,\u201D,\u201E",
+        /* morekeys_apostrophe */ "!fixedColumnOrder!3,\u201A,?,\u2018,\u2019,!text/keyspec_left_single_angle_quote,!text/keyspec_right_single_angle_quote",
         /* morekeys_single_quote */ "!fixedColumnOrder!5,!text/single_quotes,!text/single_angle_quotes",
         /* morekeys_double_quote */ "!fixedColumnOrder!5,!text/double_quotes,!text/double_angle_quotes",
         /* morekeys_tablet_double_quote */ "!fixedColumnOrder!6,!text/double_quotes,!text/single_quotes,!text/double_angle_quotes,!text/single_angle_quotes",
@@ -4263,7 +4265,7 @@ public final class KeyboardTextsTable {
 
     private static final Object[] LOCALES_AND_TEXTS = {
     // "locale", TEXT_ARRAY,  /* numberOfNonNullText/lengthOf_TEXT_ARRAY localeName */
-        "DEFAULT", TEXTS_DEFAULT, /* 181/181 DEFAULT */
+        "DEFAULT", TEXTS_DEFAULT, /* 182/182 DEFAULT */
         "af"     , TEXTS_af,    /*   7/ 13 Afrikaans */
         "ar"     , TEXTS_ar,    /*  55/110 Arabic */
         "az"     , TEXTS_az,    /*  11/ 18 Azerbaijani */

--- a/app/src/main/res/xml/rowkeys_azerty2_left5.xml
+++ b/app/src/main/res/xml/rowkeys_azerty2_left5.xml
@@ -39,8 +39,8 @@
         latin:moreKeys="!text/morekeys_d" />
     <Key
         latin:keySpec="f"
-        latin:keyHintLabel="%"
-        latin:additionalMoreKeys="%" />
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_" />
     <Key
         latin:keySpec="g"
         latin:keyHintLabel="&amp;"

--- a/app/src/main/res/xml/rowkeys_azerty2_right5.xml
+++ b/app/src/main/res/xml/rowkeys_azerty2_right5.xml
@@ -42,6 +42,6 @@
         latin:moreKeys="!text/morekeys_l" />
     <Key
         latin:keySpec="m"
-        latin:keyHintLabel="\?"
-        latin:additionalMoreKeys="\\?" />
+        latin:keyHintLabel="/"
+        latin:additionalMoreKeys="/" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_azerty3_right3.xml
+++ b/app/src/main/res/xml/rowkeys_azerty3_right3.xml
@@ -40,7 +40,8 @@
         <default>
             <Key
                 latin:keySpec="\'"
-                latin:moreKeys="!text/morekeys_single_quote" />
+                latin:keyHintLabel="\?"
+                latin:moreKeys="!text/morekeys_apostrophe" />
         </default>
     </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_qwerty2_left5.xml
+++ b/app/src/main/res/xml/rowkeys_qwerty2_left5.xml
@@ -39,8 +39,8 @@
         latin:moreKeys="!text/morekeys_d" />
     <Key
         latin:keySpec="f"
-        latin:keyHintLabel="%"
-        latin:additionalMoreKeys="%" />
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_" />
     <Key
         latin:keySpec="g"
         latin:keyHintLabel="&amp;"

--- a/app/src/main/res/xml/rowkeys_qwertz2_left5.xml
+++ b/app/src/main/res/xml/rowkeys_qwertz2_left5.xml
@@ -39,8 +39,8 @@
         latin:moreKeys="!text/morekeys_d" />
     <Key
         latin:keySpec="f"
-        latin:keyHintLabel="%"
-        latin:additionalMoreKeys="%" />
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_" />
     <Key
         latin:keySpec="g"
         latin:keyHintLabel="&amp;"

--- a/tools/make-keyboard-text/src/main/resources/values/donottranslate-more-keys.xml
+++ b/tools/make-keyboard-text/src/main/resources/values/donottranslate-more-keys.xml
@@ -255,6 +255,7 @@
     <string name="double_9qm_lqm">&#x201D;,&#x201E;,&#x201C;</string>
     <string name="double_9qm_rqm">&#x201C;,&#x201E;,&#x201D;</string>
     <string name="double_rqm_9qm">&#x201C;,&#x201D;,&#x201E;</string>
+    <string name="morekeys_apostrophe">!fixedColumnOrder!3,&#x201A;,?,&#x2018;,&#x2019;,!text/keyspec_left_single_angle_quote,!text/keyspec_right_single_angle_quote</string>
     <string name="morekeys_single_quote">!fixedColumnOrder!5,!text/single_quotes,!text/single_angle_quotes</string>
     <string name="morekeys_double_quote">!fixedColumnOrder!5,!text/double_quotes,!text/double_angle_quotes</string>
     <string name="morekeys_tablet_double_quote">!fixedColumnOrder!6,!text/double_quotes,!text/single_quotes,!text/double_angle_quotes,!text/single_angle_quotes</string>


### PR DESCRIPTION
This PR solves issue #52 where the percent symbol appears twice on AZERTY / QWERTY / QWERTZ keyboards.
Thus, on letter `f`: symbol `%` is replaced by symbol `_`.

<img width=400 src="https://github.com/Helium314/openboard/assets/139015663/77170dfd-ee79-4070-b345-b9b15a27a934">

---

Moreover, for AZERTY keyboard only:

- Symbol `?` on letter `m` is replaced by symbol `/` ;
- Added `?` symbol on `apostrophe` key as hint and it is selected first on long press

<img width=400 src="https://github.com/Helium314/openboard/assets/139015663/c41843ec-525d-452f-951e-43c0fd3e2f6c">

