### PR TITLE
Fix emoji key background for no-border themes

### DIFF
--- a/app/src/main/res/xml/key_styles_common.xml
+++ b/app/src/main/res/xml/key_styles_common.xml
@@ -78,7 +78,7 @@
         latin:backgroundType="functional" />
     <!-- emojiKeyStyle must be defined before including @xml/key_syles_enter. -->
     <switch>
-        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder|LXXBaseBorder">
+        <case latin:keyboardTheme="ICS|KLP|LXXLightBorder|LXXDarkBorder|LXXBaseBorder|LXXBase">
             <key-style
                 latin:styleName="emojiKeyStyle"
                 latin:keySpec="!icon/emoji_normal_key|!code/key_emoji"


### PR DESCRIPTION
This PR fixes the background of the emoji key when Material themes without borders are selected: indeed, no background appears when you click on this key.

**Only new themes are fixed because old ones will be deleted.**

<img width=200 src="https://github.com/Helium314/openboard/assets/139015663/a4d940a1-16ce-4389-956f-a92504e10f5f">

_Tested on Huawei phone with Android 10_