### PR TITLE
Fix all-time dark Openboard settings for Android 12+

### DIFF
--- a/app/src/main/res/values-v31/platform-themes.xml
+++ b/app/src/main/res/values-v31/platform-themes.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="platformActivityTheme" parent="@android:style/Theme.Material" />
-    <style name="platformDialogTheme" parent="@android:style/Theme.Material.Dialog"/>
+    <style name="platformActivityTheme" parent="@android:style/Theme.Material.Light">
+        <item name="android:colorAccent">@android:color/system_accent1_400</item>
+    </style>
+    <style name="platformDialogTheme" parent="@android:style/Theme.Material.Light.Dialog">
+        <item name="android:colorAccent">@android:color/system_accent1_400</item>
+    </style>
 </resources>


### PR DESCRIPTION
This PR fixes issue #751:
_**Describe the bug**
On my device I'm using light mode, however, when opening the OpenBoard settings they are displayed in dark mode._

---
I confirmed this bug on my Samsung Tablet with Android 13 too.

- Screenshot before:
  <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/7fdc9540-ccc2-450d-bc0e-e3f21ebb194d">

- Screenshot after:
  <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/796cd8e5-3143-4bfa-b406-cd566db22591">

Of course, when you use your tablet in dark mode, the Openboard settings follow the dark mode:

&emsp;&emsp;<img width=200 src="https://github.com/Helium314/openboard/assets/139015663/b01410c3-2a74-43d4-8123-6310e482cd75">
