### PR TITLE
fixed setup title text was too large on some devices & setup screen elements centered

### DIFF
--- a/app/src/main/res/layout/setup_step.xml
+++ b/app/src/main/res/layout/setup_step.xml
@@ -34,5 +34,8 @@
     <TextView
         android:id="@+id/setup_step_action_label"
         style="@style/setupStepActionLabelStyle"
-        android:layout_marginTop="@dimen/setup_step_horizontal_line_height" />
+        android:layout_marginTop="@dimen/setup_step_horizontal_line_height"
+        android:paddingTop="@dimen/setup_step_action_padding"
+        android:paddingBottom="@dimen/setup_step_action_padding"
+        android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/app/src/main/res/layout/setup_steps_cards.xml
+++ b/app/src/main/res/layout/setup_steps_cards.xml
@@ -24,7 +24,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/setup_step_vertical_padding"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:gravity="center">
         <TextView
             android:id="@+id/setup_step1_bullet"
             style="@style/setupStepBulletStyle"

--- a/app/src/main/res/layout/setup_steps_cards.xml
+++ b/app/src/main/res/layout/setup_steps_cards.xml
@@ -66,5 +66,8 @@
         android:id="@+id/setup_finish"
         android:text="@string/setup_finish_action"
         style="@style/setupStepActionLabelStyle"
-        android:layout_marginTop="@dimen/setup_step_horizontal_line_height" />
+        android:layout_marginTop="@dimen/setup_step_horizontal_line_height"
+        android:paddingTop="@dimen/setup_step_action_padding"
+        android:paddingBottom="@dimen/setup_step_action_padding"
+        android:layout_height="wrap_content"/>
 </merge>

--- a/app/src/main/res/layout/setup_steps_screen.xml
+++ b/app/src/main/res/layout/setup_steps_screen.xml
@@ -21,7 +21,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:gravity="center">
     <include layout="@layout/setup_steps_title" />
     <include layout="@layout/setup_steps_cards" />
 </LinearLayout>

--- a/app/src/main/res/layout/setup_steps_title.xml
+++ b/app/src/main/res/layout/setup_steps_title.xml
@@ -21,5 +21,6 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
     <TextView
         android:id="@+id/setup_title"
+        android:gravity="center"
         style="@style/setupTitleStyle" />
 </merge>

--- a/app/src/main/res/layout/setup_welcome_screen.xml
+++ b/app/src/main/res/layout/setup_welcome_screen.xml
@@ -21,7 +21,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:gravity="center">
     <include layout="@layout/setup_welcome_title" />
     <include layout="@layout/setup_welcome_video" />
 </LinearLayout>

--- a/app/src/main/res/layout/setup_welcome_title.xml
+++ b/app/src/main/res/layout/setup_welcome_title.xml
@@ -21,10 +21,12 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
     <TextView
         android:id="@+id/setup_welcome_title"
+        android:gravity="center"
         style="@style/setupTitleStyle" />
     <TextView
         android:id="@+id/setup_welcome_description"
         android:text="@string/setup_welcome_additional_description"
         android:layout_marginTop="@dimen/setup_welcome_description_top_margin"
+        android:gravity="center"
         style="@style/setupWelcomeDescritpionStyle" />
 </merge>

--- a/app/src/main/res/layout/setup_welcome_video.xml
+++ b/app/src/main/res/layout/setup_welcome_video.xml
@@ -25,6 +25,10 @@
         android:orientation="horizontal"
         android:paddingTop="@dimen/setup_welcome_video_top_padding"
         android:paddingBottom="@dimen/setup_welcome_video_bottom_padding">
+        <View
+            android:layout_weight="@integer/setup_welcome_video_end_padding_weight_in_screen"
+            android:layout_width="0dp"
+            android:layout_height="0dp" />
         <LinearLayout
             android:layout_weight="@integer/setup_welcome_video_weight_in_screen"
             android:layout_width="0dp"
@@ -34,6 +38,7 @@
             android:background="@color/setup_welcome_video_margin_color" >
             <VideoView
                 android:id="@+id/setup_welcome_video"
+                android:gravity="center"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@color/setup_background"

--- a/app/src/main/res/values-h1200dp-port/setup-dimens-large-tablet-port.xml
+++ b/app/src/main/res/values-h1200dp-port/setup-dimens-large-tablet-port.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">62dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">40</integer>

--- a/app/src/main/res/values-h1200dp-port/setup-dimens-large-tablet-port.xml
+++ b/app/src/main/res/values-h1200dp-port/setup-dimens-large-tablet-port.xml
@@ -25,7 +25,7 @@
     <dimen name="setup_step_action_text_size">20sp</dimen>
     <dimen name="setup_vertical_padding">96dp</dimen>
     <dimen name="setup_horizontal_padding">144dp</dimen>
-    <dimen name="setup_step_action_height">48dp</dimen>
+    <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>

--- a/app/src/main/res/values-h1200dp-port/setup-dimens-large-tablet-port.xml
+++ b/app/src/main/res/values-h1200dp-port/setup-dimens-large-tablet-port.xml
@@ -22,10 +22,10 @@
     <dimen name="setup_step_triangle_indicator_height">24dp</dimen>
     <dimen name="setup_step_title_text_size">24sp</dimen>
     <dimen name="setup_step_instruction_text_size">18sp</dimen>
-    <dimen name="setup_step_action_text_size">20sp</dimen>
+    <dimen name="setup_step_action_text_size">24sp</dimen>
     <dimen name="setup_vertical_padding">96dp</dimen>
     <dimen name="setup_horizontal_padding">144dp</dimen>
-    <dimen name="setup_step_action_height">54dp</dimen>
+    <dimen name="setup_step_action_height">62dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">12dp</dimen>
     <dimen name="setup_welcome_video_top_padding">24dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">24dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">70</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_weight_in_screen">50</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
+++ b/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">40</integer>

--- a/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
+++ b/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">10dp</dimen>
     <dimen name="setup_welcome_video_top_padding">0dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">12dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">50</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_weight_in_screen">15</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
+++ b/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
@@ -25,7 +25,7 @@
     <dimen name="setup_step_action_text_size">18sp</dimen>
     <dimen name="setup_vertical_padding">16dp</dimen>
     <dimen name="setup_horizontal_padding">16dp</dimen>
-    <dimen name="setup_step_action_height">48dp</dimen>
+    <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>

--- a/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
+++ b/app/src/main/res/values-h330dp-land/setup-dimens-large-phone-land.xml
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">10dp</dimen>
     <dimen name="setup_welcome_video_top_padding">0dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">12dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">70</integer>
+    <integer name="setup_welcome_video_weight_in_screen">50</integer>
     <integer name="setup_welcome_video_end_padding_weight_in_screen">30</integer>
 </resources>

--- a/app/src/main/res/values-h520dp-land/setup-dimens-small-tablet-land.xml
+++ b/app/src/main/res/values-h520dp-land/setup-dimens-small-tablet-land.xml
@@ -16,7 +16,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Setup wizard dimensions for small-tablet/landscape. -->
-    <dimen name="setup_title_text_size">60sp</dimen>
+    <dimen name="setup_title_text_size">50sp</dimen>
     <dimen name="setup_welcome_description_text_size">32sp</dimen>
     <dimen name="setup_step_bullet_text_size">24sp</dimen>
     <dimen name="setup_step_triangle_indicator_height">24dp</dimen>
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">12dp</dimen>
     <dimen name="setup_welcome_video_top_padding">0dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">24dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">80</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">20</integer>
+    <integer name="setup_welcome_video_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-h520dp-land/setup-dimens-small-tablet-land.xml
+++ b/app/src/main/res/values-h520dp-land/setup-dimens-small-tablet-land.xml
@@ -25,7 +25,7 @@
     <dimen name="setup_step_action_text_size">20sp</dimen>
     <dimen name="setup_vertical_padding">32dp</dimen>
     <dimen name="setup_horizontal_padding">96dp</dimen>
-    <dimen name="setup_step_action_height">48dp</dimen>
+    <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>

--- a/app/src/main/res/values-h520dp-land/setup-dimens-small-tablet-land.xml
+++ b/app/src/main/res/values-h520dp-land/setup-dimens-small-tablet-land.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">50</integer>

--- a/app/src/main/res/values-h540dp-port/setup-dimens-large-phone-port.xml
+++ b/app/src/main/res/values-h540dp-port/setup-dimens-large-phone-port.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">40</integer>

--- a/app/src/main/res/values-h540dp-port/setup-dimens-large-phone-port.xml
+++ b/app/src/main/res/values-h540dp-port/setup-dimens-large-phone-port.xml
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">6dp</dimen>
     <dimen name="setup_welcome_video_top_padding">12dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">12dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">70</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-h540dp-port/setup-dimens-large-phone-port.xml
+++ b/app/src/main/res/values-h540dp-port/setup-dimens-large-phone-port.xml
@@ -25,7 +25,7 @@
     <dimen name="setup_step_action_text_size">18sp</dimen>
     <dimen name="setup_vertical_padding">8dp</dimen>
     <dimen name="setup_horizontal_padding">16dp</dimen>
-    <dimen name="setup_step_action_height">48dp</dimen>
+    <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>

--- a/app/src/main/res/values-h720dp-land/setup-dimens-large-tablet-land.xml
+++ b/app/src/main/res/values-h720dp-land/setup-dimens-large-tablet-land.xml
@@ -22,10 +22,10 @@
     <dimen name="setup_step_triangle_indicator_height">24dp</dimen>
     <dimen name="setup_step_title_text_size">24sp</dimen>
     <dimen name="setup_step_instruction_text_size">18sp</dimen>
-    <dimen name="setup_step_action_text_size">20sp</dimen>
+    <dimen name="setup_step_action_text_size">24sp</dimen>
     <dimen name="setup_vertical_padding">96dp</dimen>
     <dimen name="setup_horizontal_padding">160dp</dimen>
-    <dimen name="setup_step_action_height">54dp</dimen>
+    <dimen name="setup_step_action_height">62dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">12dp</dimen>
     <dimen name="setup_welcome_video_top_padding">0dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">24dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">80</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">20</integer>
+    <integer name="setup_welcome_video_weight_in_screen">50</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-h720dp-land/setup-dimens-large-tablet-land.xml
+++ b/app/src/main/res/values-h720dp-land/setup-dimens-large-tablet-land.xml
@@ -25,7 +25,7 @@
     <dimen name="setup_step_action_text_size">20sp</dimen>
     <dimen name="setup_vertical_padding">96dp</dimen>
     <dimen name="setup_horizontal_padding">160dp</dimen>
-    <dimen name="setup_step_action_height">48dp</dimen>
+    <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>

--- a/app/src/main/res/values-h720dp-land/setup-dimens-large-tablet-land.xml
+++ b/app/src/main/res/values-h720dp-land/setup-dimens-large-tablet-land.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">62dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">50</integer>

--- a/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
+++ b/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">12dp</dimen>
     <dimen name="setup_welcome_video_top_padding">24dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">24dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">70</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_weight_in_screen">40</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
+++ b/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">40</integer>

--- a/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
+++ b/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
@@ -16,8 +16,8 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Setup wizard dimensions for small-tablet/portrait. -->
-    <dimen name="setup_title_text_size">72sp</dimen>
-    <dimen name="setup_welcome_description_text_size">36sp</dimen>
+    <dimen name="setup_title_text_size">48sp</dimen>
+    <dimen name="setup_welcome_description_text_size">26sp</dimen>
     <dimen name="setup_step_bullet_text_size">24sp</dimen>
     <dimen name="setup_step_triangle_indicator_height">24dp</dimen>
     <dimen name="setup_step_title_text_size">24sp</dimen>

--- a/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
+++ b/app/src/main/res/values-h800dp-port/setup-dimens-small-tablet-port.xml
@@ -25,7 +25,7 @@
     <dimen name="setup_step_action_text_size">20sp</dimen>
     <dimen name="setup_vertical_padding">32dp</dimen>
     <dimen name="setup_horizontal_padding">64dp</dimen>
-    <dimen name="setup_step_action_height">48dp</dimen>
+    <dimen name="setup_step_action_height">54dp</dimen>
     <dimen name="setup_step_horizontal_padding">24dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">12dp</dimen>
     <dimen name="setup_step_vertical_padding">16dp</dimen>

--- a/app/src/main/res/values-land/setup-dimens-small-phone-land.xml
+++ b/app/src/main/res/values-land/setup-dimens-small-phone-land.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">42dp</dimen>
     <dimen name="setup_step_horizontal_padding">20dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">10dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">12dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">40</integer>

--- a/app/src/main/res/values-land/setup-dimens-small-phone-land.xml
+++ b/app/src/main/res/values-land/setup-dimens-small-phone-land.xml
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">12dp</dimen>
     <dimen name="setup_welcome_video_top_padding">0dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">12dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">70</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_weight_in_screen">20</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-port/setup-dimens-small-phone-port.xml
+++ b/app/src/main/res/values-port/setup-dimens-small-phone-port.xml
@@ -25,7 +25,7 @@
     <dimen name="setup_step_action_text_size">16sp</dimen>
     <dimen name="setup_vertical_padding">2dp</dimen>
     <dimen name="setup_horizontal_padding">12dp</dimen>
-    <dimen name="setup_step_action_height">42dp</dimen>
+    <dimen name="setup_step_action_height">46dp</dimen>
     <dimen name="setup_step_horizontal_padding">20dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">10dp</dimen>
     <dimen name="setup_step_vertical_padding">12dp</dimen>

--- a/app/src/main/res/values-port/setup-dimens-small-phone-port.xml
+++ b/app/src/main/res/values-port/setup-dimens-small-phone-port.xml
@@ -36,6 +36,6 @@
     <dimen name="setup_welcome_description_top_margin">4dp</dimen>
     <dimen name="setup_welcome_video_top_padding">12dp</dimen>
     <dimen name="setup_welcome_video_bottom_padding">12dp</dimen>
-    <integer name="setup_welcome_video_weight_in_screen">70</integer>
-    <integer name="setup_welcome_video_end_padding_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_weight_in_screen">30</integer>
+    <integer name="setup_welcome_video_end_padding_weight_in_screen">5</integer>
 </resources>

--- a/app/src/main/res/values-port/setup-dimens-small-phone-port.xml
+++ b/app/src/main/res/values-port/setup-dimens-small-phone-port.xml
@@ -28,6 +28,7 @@
     <dimen name="setup_step_action_height">46dp</dimen>
     <dimen name="setup_step_horizontal_padding">20dp</dimen>
     <dimen name="setup_step_horizontal_padding_half">10dp</dimen>
+    <dimen name="setup_step_action_padding">6dp</dimen>
     <dimen name="setup_step_vertical_padding">12dp</dimen>
     <dimen name="setup_step_horizontal_line_height">2dp</dimen>
     <integer name="setup_title_weight_in_screen">40</integer>


### PR DESCRIPTION
<table style="width:100%; border: none;">
  <tr>
    <td style="border: none;"><img src="https://github.com/Helium314/openboard/assets/31377578/a97ea16c-cbd5-432a-bcf7-25fc43a0b6d5" width="400" /></td>
    <td style="border: none;"><img src="https://github.com/Helium314/openboard/assets/31377578/a06a75a0-5961-4064-ba98-56572ecdb10b" width="400" /></td>
  </tr>
  <tr>
    <td style="border: none;"><img src="https://github.com/Helium314/openboard/assets/31377578/035cf542-99b6-4848-81cb-4776c652c641" width="400" /></td>
    <td style="border: none;"><img src="https://github.com/Helium314/openboard/assets/31377578/0bc9adad-38df-403f-a344-4304c8b8697a" width="400" /></td>
  </tr>
  <tr>
    <td style="border: none;">Before</td>
    <td style="border: none;">After</td>
  </tr>
</table>

Tested on Galaxy M32, 3.4 WQVGA, Nexus S, Pixel 5