### PR TITLE
Fix buttons colour in one-handed mode

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/KeyboardWrapperView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/KeyboardWrapperView.kt
@@ -9,6 +9,7 @@ import android.widget.FrameLayout
 import android.widget.ImageButton
 import org.dslul.openboard.inputmethod.keyboard.KeyboardActionListener
 import org.dslul.openboard.inputmethod.latin.common.Constants
+import org.dslul.openboard.inputmethod.latin.settings.Settings
 
 class KeyboardWrapperView @JvmOverloads constructor(
         context: Context,
@@ -51,6 +52,12 @@ class KeyboardWrapperView @JvmOverloads constructor(
 
         stopOneHandedModeBtn.setOnClickListener(this)
         switchOneHandedModeBtn.setOnClickListener(this)
+
+        val colors = Settings.getInstance().current.mColors
+        if (colors.isCustom) {
+            stopOneHandedModeBtn.colorFilter = colors.keyTextFilter
+            switchOneHandedModeBtn.colorFilter = colors.keyTextFilter
+        }
     }
 
     @SuppressLint("RtlHardcoded")


### PR DESCRIPTION
This PR fixes buttons color in one-handed mode.

<img width=400 src="https://github.com/Helium314/openboard/assets/139015663/00c62646-17ae-4fab-9406-36d62c2cdd77">

_Tested on Huawei phone with Android 10._