### PR TITLE
made cancel button from input styles use app string

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
@@ -95,7 +95,7 @@ public final class AdvancedSettingsFragment extends SubScreenFragment {
                                     startActivityForResult(intent, REQUEST_CODE_GESTURE_LIBRARY);
                                 }
                             })
-                            .setNegativeButton(android.R.string.cancel, null);
+                            .setNegativeButton(R.string.cancel, null);
                     libfile = new File(context.getFilesDir().getAbsolutePath() + File.separator + JniLibName.JNI_LIB_IMPORT_FILE_NAME);
                     if (libfile.exists())
                         builder.setNeutralButton(R.string.load_gesture_library_button_delete, new DialogInterface.OnClickListener() {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorPickerDialog.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorPickerDialog.java
@@ -63,7 +63,7 @@ public class ColorPickerDialog extends AlertDialog implements SeekBar.OnSeekBarC
         });
 
         // set on ok and on cancel listeners
-        setButton(BUTTON_NEGATIVE, context.getText(android.R.string.cancel), (dialogInterface, i) -> dismiss());
+        setButton(BUTTON_NEGATIVE, context.getText(R.string.cancel), (dialogInterface, i) -> dismiss());
         setButton(BUTTON_POSITIVE, context.getText(android.R.string.ok), (dialogInterface, i) -> {
             final int value = Color.rgb(
                     mSeekBarRed.getProgress(),

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/CustomInputStylePreference.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/CustomInputStylePreference.java
@@ -132,10 +132,10 @@ final class CustomInputStylePreference extends DialogPreference
         builder.setCancelable(true).setOnCancelListener(this);
         if (isIncomplete()) {
             builder.setPositiveButton(R.string.add, this)
-                    .setNegativeButton(android.R.string.cancel, this);
+                    .setNegativeButton(R.string.cancel, this);
         } else {
             builder.setPositiveButton(R.string.save, this)
-                    .setNeutralButton(android.R.string.cancel, this)
+                    .setNeutralButton(R.string.cancel, this)
                     .setNegativeButton(R.string.remove, this);
             final SubtypeLocaleItem localeItem = new SubtypeLocaleItem(mSubtype);
             final KeyboardLayoutSetItem layoutItem = new KeyboardLayoutSetItem(mSubtype);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/DictionarySettingsFragment.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/DictionarySettingsFragment.kt
@@ -244,7 +244,7 @@ class DictionarySettingsFragment : SubScreenFragment() {
             )
             AlertDialog.Builder(DialogUtils.getPlatformDialogThemeContext(activity))
                 .setMessage(message)
-                .setNegativeButton(android.R.string.cancel) { _, _ -> cachedDictionaryFile.delete() }
+                .setNegativeButton(R.string.cancel) { _, _ -> cachedDictionaryFile.delete() }
                 .setPositiveButton(R.string.dictionary_file_wrong_locale_ok) { _, _ ->
                     checkCachedDictionaryVersion(currentDictLocale, newHeader)
                 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
@@ -77,7 +77,7 @@ public final class SecondaryLocaleSettingsFragment extends SubScreenFragment {
         final AlertDialog.Builder builder = new AlertDialog.Builder(
                 DialogUtils.getPlatformDialogThemeContext(getActivity()))
                 .setTitle(R.string.language_selection_title)
-                .setPositiveButton(android.R.string.cancel, null);
+                .setPositiveButton(R.string.cancel, null);
 
         if (locales.isEmpty()) {
             builder.setMessage(R.string.no_secondary_locales)

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SeekBarDialogPreference.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SeekBarDialogPreference.java
@@ -105,7 +105,7 @@ public final class SeekBarDialogPreference extends DialogPreference
     @Override
     protected void onPrepareDialogBuilder(final AlertDialog.Builder builder) {
         builder.setPositiveButton(android.R.string.ok, this)
-            .setNegativeButton(android.R.string.cancel, this)
+            .setNegativeButton(R.string.cancel, this)
             .setNeutralButton(R.string.button_default, this);
     }
 


### PR DESCRIPTION
Previously the `Cancel` button used a system-provided string. Now it'll use the string from the app's resources for better translation.

<img src="https://github.com/Helium314/openboard/assets/31377578/087a3609-2828-4884-b8c5-264b92e0f959" height="600">