### PR TITLE
Fix punctuation marks color in suggestion strip

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripLayoutHelper.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripLayoutHelper.java
@@ -544,6 +544,9 @@ final class SuggestionStripLayoutHelper {
             wordView.setTextColor(mColorAutoCorrect);
             stripView.addView(wordView);
             setLayoutWeight(wordView, 1.0f, mSuggestionsStripHeight);
+            final Colors colors = Settings.getInstance().getCurrent().mColors;
+            if (colors.isCustom)
+                wordView.setTextColor(colors.keyText);
         }
         mMoreSuggestionsAvailable = (punctuationSuggestions.size() > countInStrip);
         return countInStrip;


### PR DESCRIPTION
This PR corrects the color of punctuation marks that only appear when _Next word suggestion_ is deactivated in the _Correction_ settings.

<img width=300 src="https://github.com/Helium314/openboard/assets/139015663/1356d908-b507-4113-ae18-151a1620cbd1">
<img width=300 src="https://github.com/Helium314/openboard/assets/139015663/89009ae5-72ac-461d-a1bc-97544658ea833">

