### PR TITLE
Update symbols "apostrophe" key: "?" is now always selected

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -253,16 +253,15 @@ public final class KeyboardTextsTable {
         /* 169: 0 */ "double_9qm_lqm",
         /* 170: 0 */ "double_9qm_rqm",
         /* 171: 0 */ "double_rqm_9qm",
-        /* 172: 0 */ "morekeys_apostrophe",
-        /* 173: 0 */ "morekeys_single_quote",
-        /* 174: 0 */ "morekeys_double_quote",
-        /* 175: 0 */ "morekeys_tablet_double_quote",
-        /* 176: 0 */ "keyspec_emoji_action_key",
-        /* 177: 0 */ "keyspec_emoji_normal_key",
-        /* 178: 0 */ "keyspec_clipboard_action_key",
-        /* 179: 0 */ "keyspec_clipboard_normal_key",
-        /* 180: 0 */ "keyspec_start_onehanded_mode",
-        /* 181: 0 */ "keyspec_language_switch",
+        /* 172: 0 */ "morekeys_single_quote",
+        /* 173: 0 */ "morekeys_double_quote",
+        /* 174: 0 */ "morekeys_tablet_double_quote",
+        /* 175: 0 */ "keyspec_emoji_action_key",
+        /* 176: 0 */ "keyspec_emoji_normal_key",
+        /* 177: 0 */ "keyspec_clipboard_action_key",
+        /* 178: 0 */ "keyspec_clipboard_normal_key",
+        /* 179: 0 */ "keyspec_start_onehanded_mode",
+        /* 180: 0 */ "keyspec_language_switch",
     };
 
     private static final String EMPTY = "";
@@ -483,7 +482,6 @@ public final class KeyboardTextsTable {
         /* double_9qm_lqm */ "\u201D,\u201E,\u201C",
         /* double_9qm_rqm */ "\u201C,\u201E,\u201D",
         /* double_rqm_9qm */ "\u201C,\u201D,\u201E",
-        /* morekeys_apostrophe */ "!fixedColumnOrder!3,\u201A,?,\u2018,\u2019,!text/keyspec_left_single_angle_quote,!text/keyspec_right_single_angle_quote",
         /* morekeys_single_quote */ "!fixedColumnOrder!5,!text/single_quotes,!text/single_angle_quotes",
         /* morekeys_double_quote */ "!fixedColumnOrder!5,!text/double_quotes,!text/double_angle_quotes",
         /* morekeys_tablet_double_quote */ "!fixedColumnOrder!6,!text/double_quotes,!text/single_quotes,!text/double_angle_quotes,!text/single_angle_quotes",
@@ -4265,7 +4263,7 @@ public final class KeyboardTextsTable {
 
     private static final Object[] LOCALES_AND_TEXTS = {
     // "locale", TEXT_ARRAY,  /* numberOfNonNullText/lengthOf_TEXT_ARRAY localeName */
-        "DEFAULT", TEXTS_DEFAULT, /* 182/182 DEFAULT */
+        "DEFAULT", TEXTS_DEFAULT, /* 181/181 DEFAULT */
         "af"     , TEXTS_af,    /*   7/ 13 Afrikaans */
         "ar"     , TEXTS_ar,    /*  55/110 Arabic */
         "az"     , TEXTS_az,    /*  11/ 18 Azerbaijani */

--- a/app/src/main/res/xml/rowkeys_azerty3_right3.xml
+++ b/app/src/main/res/xml/rowkeys_azerty3_right3.xml
@@ -41,7 +41,7 @@
             <Key
                 latin:keySpec="\'"
                 latin:keyHintLabel="\?"
-                latin:moreKeys="!text/morekeys_apostrophe" />
+                latin:additionalMoreKeys="\?,!text/single_quotes,!text/single_angle_quotes" />
         </default>
     </switch>
 </merge>

--- a/tools/make-keyboard-text/src/main/resources/values/donottranslate-more-keys.xml
+++ b/tools/make-keyboard-text/src/main/resources/values/donottranslate-more-keys.xml
@@ -255,7 +255,6 @@
     <string name="double_9qm_lqm">&#x201D;,&#x201E;,&#x201C;</string>
     <string name="double_9qm_rqm">&#x201C;,&#x201E;,&#x201D;</string>
     <string name="double_rqm_9qm">&#x201C;,&#x201D;,&#x201E;</string>
-    <string name="morekeys_apostrophe">!fixedColumnOrder!3,&#x201A;,?,&#x2018;,&#x2019;,!text/keyspec_left_single_angle_quote,!text/keyspec_right_single_angle_quote</string>
     <string name="morekeys_single_quote">!fixedColumnOrder!5,!text/single_quotes,!text/single_angle_quotes</string>
     <string name="morekeys_double_quote">!fixedColumnOrder!5,!text/double_quotes,!text/double_angle_quotes</string>
     <string name="morekeys_tablet_double_quote">!fixedColumnOrder!6,!text/double_quotes,!text/single_quotes,!text/double_angle_quotes,!text/single_angle_quotes</string>


### PR DESCRIPTION
In PR #60, the "?" symbol was added to the apostrophe key for the AZERTY keyboard.

However, the "?" symbol was not always selected first, depending on the keyboard configuration.

This is now fixed.

<img width=300 src="https://github.com/Helium314/openboard/assets/139015663/a3ad07ea-da33-40db-b3e8-f7769343ac46">
<img width=300 src="https://github.com/Helium314/openboard/assets/139015663/0ee75c47-c12e-4f53-900b-f1aa0f15aceb">


