### PR TITLE
Add auto theme for custom themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Changes to OpenBoard:
 * Fix white background of emoji tab selector on AMOLED theme for some Android versions, https://github.com/Helium314/openboard/pull/26
 * Fix issue with spell checker incorrectly flagging words before a period as wrong on newer Android versions, https://github.com/openboard-team/openboard/pull/679 (maybe not properly fixed)
 * Fix always-dark settings on some Android versions, https://github.com/Helium314/openboard/pull/69
+* Fix bug with space before word being deleted in some apps / input fields, https://github.com/Helium314/openboard/commit/ce0bf06545c4547d3fc5791cc769508db0a89e87
+* Allow using auto theme on some devices with Android 9
+* Add auto theme for the new theming system
 
 Further plan / to do:
 * ~upgrade dependencies~

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -99,6 +99,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         final boolean themeUpdated = updateKeyboardThemeAndContextThemeWrapper(
                 displayContext, KeyboardTheme.getKeyboardTheme(displayContext /* context */));
         if (themeUpdated && mKeyboardView != null) {
+            Settings settings = Settings.getInstance();
+            settings.loadSettings(displayContext, settings.getCurrent().mLocale, settings.getCurrent().mInputAttributes);
             mLatinIME.setInputView(onCreateInputView(displayContext, mIsHardwareAcceleratedDrawingEnabled));
         }
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
@@ -345,6 +345,11 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
             if (THEME_VARIANT_HOLO_USER.equals(variant)) return THEME_ID_KLP_CUSTOM;
             return THEME_ID_KLP;
         }
+        // check custom before dayNight, because now both can match
+        if (THEME_VARIANT_CUSTOM.equals(variant)) {
+            if (keyBorders) return THEME_ID_LXX_CUSTOM_BORDER;
+            return THEME_ID_LXX_CUSTOM;
+        }
         if (dayNight) {
             if (keyBorders) return THEME_ID_LXX_AUTO_BORDER;
             if (amoledMode) return THEME_ID_LXX_AUTO_AMOLED;
@@ -354,10 +359,6 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
             if (keyBorders) return THEME_ID_LXX_DARK_BORDER;
             if (amoledMode) return THEME_ID_LXX_DARK_AMOLED;
             return THEME_ID_LXX_DARK;
-        }
-        if (THEME_VARIANT_CUSTOM.equals(variant)) {
-            if (keyBorders) return THEME_ID_LXX_CUSTOM_BORDER;
-            return THEME_ID_LXX_CUSTOM;
         }
         if (keyBorders) return THEME_ID_LXX_LIGHT_BORDER;
         return THEME_ID_LXX_LIGHT;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
@@ -369,7 +369,9 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
     public static final String THEME_DARKER = "darker";
     public static final String THEME_BLACK = "black";
     public static final String THEME_USER = "user";
+    public static final String THEME_USER_DARK = "user_dark";
     public static final String[] CUSTOM_THEME_VARIANTS = new String[] { THEME_LIGHT, THEME_DARK, THEME_DARKER, THEME_BLACK, THEME_USER };
+    public static final String[] CUSTOM_THEME_VARIANTS_DARK = new String[] { THEME_DARK, THEME_DARKER, THEME_BLACK, THEME_USER_DARK };
 
     // todo (later): material you, system accent, ...
     // todo: copies of original themes might need adjustments, though maybe it's only Colors that needs to be adjusted
@@ -382,6 +384,13 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                 final int hintTextColor = prefs.getInt(Settings.PREF_THEME_USER_COLOR_HINT_TEXT, Color.WHITE);
                 final int background = prefs.getInt(Settings.PREF_THEME_USER_COLOR_BACKGROUND, Color.DKGRAY);
                 return new Colors(accent, background, keyBgColor, Colors.brightenOrDarken(keyBgColor, true), keyBgColor, keyTextColor, hintTextColor);
+            case THEME_USER_DARK:
+                final int accent2 = prefs.getInt(Settings.PREF_THEME_USER_DARK_COLOR_ACCENT, Color.BLUE);
+                final int keyBgColor2 = prefs.getInt(Settings.PREF_THEME_USER_DARK_COLOR_KEYS, Color.LTGRAY);
+                final int keyTextColor2 = prefs.getInt(Settings.PREF_THEME_USER_DARK_COLOR_TEXT, Color.WHITE);
+                final int hintTextColor2 = prefs.getInt(Settings.PREF_THEME_USER_DARK_COLOR_HINT_TEXT, Color.WHITE);
+                final int background2 = prefs.getInt(Settings.PREF_THEME_USER_DARK_COLOR_BACKGROUND, Color.DKGRAY);
+                return new Colors(accent2, background2, keyBgColor2, Colors.brightenOrDarken(keyBgColor2, true), keyBgColor2, keyTextColor2, hintTextColor2);
             case THEME_DARK:
                 return new Colors(
                         ContextCompat.getColor(context, R.color.gesture_trail_color_lxx_dark),

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.java
@@ -1,7 +1,6 @@
 package org.dslul.openboard.inputmethod.latin.common;
 
 import android.content.res.ColorStateList;
-import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
 
@@ -55,10 +54,10 @@ public class Colors {
     }
 
     // todo (later): remove this and isCustom, once the old themes can be completely replaced
-    public Colors(int themeId, int nightModeFlags) {
+    public Colors(int themeId, final boolean isNight) {
         isCustom = false;
         if (KeyboardTheme.getIsDayNight(themeId)) {
-            if (nightModeFlags == Configuration.UI_MODE_NIGHT_NO)
+            if (!isNight)
                 navBar = Color.rgb(236, 239, 241);
             else if (themeId == KeyboardTheme.THEME_ID_LXX_DARK)
                 navBar = Color.rgb(38, 50, 56);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -65,6 +65,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_THEME_FAMILY = "theme_family";
     public static final String PREF_THEME_VARIANT = "theme_variant";
     public static final String PREF_CUSTOM_THEME_VARIANT = "custom_theme_variant";
+    public static final String PREF_CUSTOM_THEME_VARIANT_NIGHT = "custom_theme_variant_night";
     public static final String PREF_THEME_KEY_BORDERS = "theme_key_borders";
     public static final String PREF_THEME_DAY_NIGHT = "theme_auto_day_night";
     public static final String PREF_THEME_AMOLED_MODE = "theme_amoled_mode";
@@ -557,9 +558,13 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
                 prefs.getBoolean(Settings.PREF_THEME_DAY_NIGHT, false),
                 prefs.getBoolean(Settings.PREF_THEME_AMOLED_MODE, false)
         );
+        // todo: night mode can be unspecified -> maybe need to adjust for correct behavior on some devices?
+        final boolean isNight = (context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
         if (!KeyboardTheme.getIsCustom(keyboardThemeId))
-            return new Colors(keyboardThemeId, context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK);
+            return new Colors(keyboardThemeId, isNight);
 
+        if (isNight && prefs.getBoolean(Settings.PREF_THEME_DAY_NIGHT, false))
+            return KeyboardTheme.getCustomTheme(prefs.getString(Settings.PREF_CUSTOM_THEME_VARIANT_NIGHT, KeyboardTheme.THEME_DARKER), context, prefs);
         return KeyboardTheme.getCustomTheme(prefs.getString(Settings.PREF_CUSTOM_THEME_VARIANT, KeyboardTheme.THEME_LIGHT), context, prefs);
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -75,6 +75,11 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_THEME_USER_COLOR_BACKGROUND = "theme_color_background";
     public static final String PREF_THEME_USER_COLOR_KEYS = "theme_color_keys";
     public static final String PREF_THEME_USER_COLOR_ACCENT = "theme_color_accent";
+    public static final String PREF_THEME_USER_DARK_COLOR_TEXT = "theme_dark_color_text";
+    public static final String PREF_THEME_USER_DARK_COLOR_HINT_TEXT = "theme_dark_color_hint_text";
+    public static final String PREF_THEME_USER_DARK_COLOR_BACKGROUND = "theme_dark_color_background";
+    public static final String PREF_THEME_USER_DARK_COLOR_KEYS = "theme_dark_color_keys";
+    public static final String PREF_THEME_USER_DARK_COLOR_ACCENT = "theme_dark_color_accent";
     // PREF_VOICE_MODE_OBSOLETE is obsolete. Use PREF_VOICE_INPUT_KEY instead.
     public static final String PREF_VOICE_MODE_OBSOLETE = "voice_mode";
     public static final String PREF_VOICE_INPUT_KEY = "pref_voice_input_key";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -640,6 +640,12 @@ disposition rather than other common dispositions for Latin languages. [CHAR LIM
     <string name="key_borders">Key borders</string>
     <!-- Option for choosing auto day/night theme switch [CHAR LIMIT=33] -->
     <string name="day_night_mode">Auto day/night mode</string>
+    <!-- Message for the dialog to choose which user-defined theme to edit -->
+    <string name="day_or_night_colors">Edit day or night colors?</string>
+    <!-- Button of the dialog above for "day"-->
+    <string name="day_or_night_day">Day</string>
+    <!-- Button of the dialog above for "night"-->
+    <string name="day_or_night_night">Night</string>
     <!-- Description for "day_night_mode" option. -->
     <string name="day_night_mode_summary">Appearance will follow system settings</string>
     <!-- Option for enabling AMOLED mode [CHAR LIMIT=33] -->

--- a/app/src/main/res/xml/prefs_screen_appearance.xml
+++ b/app/src/main/res/xml/prefs_screen_appearance.xml
@@ -35,6 +35,10 @@
             android:key="custom_theme_variant"
             android:title="@string/theme_variant"/>
 
+        <ListPreference
+            android:key="custom_theme_variant_night"
+            android:title="@string/theme_variant"/>
+
         <CheckBoxPreference
             android:key="theme_key_borders"
             android:title="@string/key_borders"/>


### PR DESCRIPTION
Automatic theme switch is the main feature missing compared to the old themes.

This PR makes the ___Auto day/night mode___ setting work for custom themes too, and also enables this setting for some Android 9 devices.
If ___Auto day/night mode___ is enabled, user can choose a night theme from the custom theme list. The "normal" theme then is used for day only.

It's still a draft because some things are not working / need to be improved:
* ~Automatic switching is not working, you need to manually reload the keyboard (switch to a different one and switch back).~
The original auto theme does switch correctly.
* ~The list preference for night themes isn't properly enabled/disabled on changing auto setting.~ Reason for this is in a _todo_.
Probably it would be best to re-arrange how preferences are enabled / disabled, considering the current way is rather complex and that the old themes will be removed soon.
* Instead of enabling/disabling the night theme preference, it should ideally be hidden.
* ~A second user-defined theme should be added, so the auto-theme can switch between them.~
* ~The night theme list should only allow choosing dark themes.~