### PR TITLE
Fix removing delete key background in emoji view

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -530,7 +530,11 @@ public final class EmojiPalettesView extends LinearLayout
         }
 
         private void onTouchCanceled(final View v) {
-            v.setBackgroundColor(Color.TRANSPARENT);
+            final Colors colors = Settings.getInstance().getCurrent().mColors;
+            if (colors.isCustom) {
+                DrawableCompat.setTintList(v.getBackground(), colors.functionalKeyStateList);
+                DrawableCompat.setTintMode(v.getBackground(), PorterDuff.Mode.MULTIPLY);
+            }
         }
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -530,11 +530,7 @@ public final class EmojiPalettesView extends LinearLayout
         }
 
         private void onTouchCanceled(final View v) {
-            final Colors colors = Settings.getInstance().getCurrent().mColors;
-            if (colors.isCustom) {
-                DrawableCompat.setTintList(v.getBackground(), colors.functionalKeyStateList);
-                DrawableCompat.setTintMode(v.getBackground(), PorterDuff.Mode.MULTIPLY);
-            }
+            v.setPressed(false);
         }
     }
 }


### PR DESCRIPTION
This PR fixes the fact that in emoji view, when you swipe on delete key, the background disappears.

_Tested on Huawei phone with Android 10 and Samsung tablet with Android 13._