### PR TITLE
Remove suggestion appears when only 1 word is displayed

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
@@ -315,7 +315,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(
                 Constants.NOT_A_CODE, this);
         if (isShowingMoreSuggestionPanel() || !showMoreSuggestions()) {
-            for (int i = 0; i < mStartIndexOfMoreSuggestions; i++) {
+            for (int i = 0; i <= mStartIndexOfMoreSuggestions; i++) {
                 if (view == mWordViews.get(i)) {
                     showDeleteSuggestionDialog(mWordViews.get(i));
                     return true;


### PR DESCRIPTION
This PR fixes the fact that in the suggestion strip, when only one word is displayed, "Remove suggestion" window doesn't appear.

After:

https://github.com/Helium314/openboard/assets/139015663/7ff8b320-7aff-4e71-9b54-b565707d86e3

