### PR TITLE
Fixed missed background color of "Previous_key"

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
@@ -674,6 +674,7 @@ public class KeyboardView extends View {
         if (this.getClass() != MoreKeysKeyboardView.class) return false;
         final String iconName = KeyboardIconsSet.getIconName(key.getIconId());
         return iconName.equals(KeyboardIconsSet.NAME_NEXT_KEY)
+                || iconName.equals(KeyboardIconsSet.NAME_PREVIOUS_KEY)
                 || iconName.equals(KeyboardIconsSet.NAME_CLIPBOARD_ACTION_KEY)
                 || iconName.equals(KeyboardIconsSet.NAME_EMOJI_ACTION_KEY);
     }


### PR DESCRIPTION
"Previous_key" did not follow the color of other action keys of the enter key.
Now fixed 👍

<img width=400 src="https://github.com/Helium314/openboard/assets/139015663/2fd618d7-dafb-4103-be8f-1089b509bfcb">

_Tested on Huawei phone with Android 10 and Samsung tablet with Android 13_