### PR TITLE
Fixed background color of "Label_action_key"

### DIFF
--- a/app/src/main/res/xml/key_styles_actions.xml
+++ b/app/src/main/res/xml/key_styles_actions.xml
@@ -126,7 +126,7 @@
                 latin:styleName="customLabelActionKeyStyle"
                 latin:keySpec="dummy_label|!code/key_enter"
                 latin:keyLabelFlags="fromCustomActionLabel"
-                latin:backgroundType="functional"
+                latin:backgroundType="action"
                 latin:parentStyle="defaultEnterKeyStyle" />
         </default>
     </switch>


### PR DESCRIPTION
"Label_action_key" did not follow color of enter key.
This key appears when you want to rename a file for example.
Now fixed 👍

<img width=400 src="https://github.com/Helium314/openboard/assets/139015663/248c1fde-d31a-4ab8-b3fd-52f9c0e44166">

_Tested on Huawei phone with Android 10 and Samsung tablet with Android 13_