### PR TITLE
Implemented "SlidingKeyInput" to Numpad

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Key.java
@@ -42,6 +42,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static org.dslul.openboard.inputmethod.keyboard.internal.KeyboardIconsSet.ICON_UNDEFINED;
+import static org.dslul.openboard.inputmethod.latin.common.Constants.CODE_ALPHA_FROM_NUMPAD;
 import static org.dslul.openboard.inputmethod.latin.common.Constants.CODE_OUTPUT_TEXT;
 import static org.dslul.openboard.inputmethod.latin.common.Constants.CODE_SHIFT;
 import static org.dslul.openboard.inputmethod.latin.common.Constants.CODE_SWITCH_ALPHA_SYMBOL;
@@ -709,7 +710,7 @@ public class Key implements Comparable<Key> {
     }
 
     public final boolean isModifier() {
-        return mCode == CODE_SHIFT || mCode == CODE_SWITCH_ALPHA_SYMBOL;
+        return mCode == CODE_SHIFT || mCode == CODE_SWITCH_ALPHA_SYMBOL || mCode == CODE_ALPHA_FROM_NUMPAD;
     }
 
     public final boolean isRepeatable() {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardState.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardState.java
@@ -75,7 +75,7 @@ public final class KeyboardState {
 
     private ShiftKeyState mShiftKeyState = new ShiftKeyState("Shift");
     private ModifierKeyState mSymbolKeyState = new ModifierKeyState("Symbol");
-
+    private ModifierKeyState mAlphaNumpadKeyState = new ModifierKeyState("AlphaNumpad");
     // TODO: Merge {@link #mSwitchState}, {@link #mIsAlphabetMode}, {@link #mAlphabetShiftState},
     // {@link #mIsSymbolShifted}, {@link #mPrevMainKeyboardWasShiftLocked}, and
     // {@link #mPrevSymbolsKeyboardWasShifted} into single state variable.
@@ -86,6 +86,8 @@ public final class KeyboardState {
     private static final int SWITCH_STATE_MOMENTARY_SYMBOL_AND_MORE = 4;
     private static final int SWITCH_STATE_MOMENTARY_ALPHA_SHIFT = 5;
     private int mSwitchState = SWITCH_STATE_ALPHA;
+    private static final int SWITCH_STATE_NUMPAD = 6;
+    private static final int SWITCH_STATE_MOMENTARY_NUMPAD_AND_ALPHA = 7;
 
     private static final int MODE_ALPHABET = 0;
     private static final int MODE_SYMBOLS = 1;
@@ -294,6 +296,23 @@ public final class KeyboardState {
         }
     }
 
+    private void toggleNumpadAndAlphabet(final int autoCapsFlags, final int recapitalizeMode) {
+        if (DEBUG_INTERNAL_ACTION) {
+            Log.d(TAG, "toggleNumpadAndAlphabet: "
+                    + stateToString(autoCapsFlags, recapitalizeMode));
+        }
+        if (mMode == MODE_NUMPAD) {
+            mPrevMainKeyboardWasShiftLocked = mAlphabetShiftState.isShiftLocked();
+            setAlphabetKeyboard(autoCapsFlags, recapitalizeMode);
+            if (mPrevMainKeyboardWasShiftLocked) {
+                setShiftLocked(true);
+            }
+            mPrevMainKeyboardWasShiftLocked = false;
+        } else {
+            setNumpadKeyboard();
+        }
+    }
+
     // TODO: Remove this method. Come up with a more comprehensive way to reset the keyboard layout
     // when a keyboard layout set doesn't get reloaded in LatinIME.onStartInputViewInternal().
     private void resetKeyboardStateToAlphabet(final int autoCapsFlags, final int recapitalizeMode) {
@@ -392,7 +411,7 @@ public final class KeyboardState {
         mPrevMainKeyboardWasShiftLocked = mAlphabetShiftState.isShiftLocked();
         mAlphabetShiftState.setShiftLocked(false);
         mSwitchActions.setNumpadKeyboard();
-
+        mSwitchState = SWITCH_STATE_NUMPAD;
     }
 
     private void setOneHandedModeEnabled(boolean enabled) {
@@ -427,6 +446,8 @@ public final class KeyboardState {
             // Nothing to do here. See {@link #onReleaseKey(int,boolean)}.
         } else if (code == Constants.CODE_SWITCH_ALPHA_SYMBOL) {
             onPressSymbol(autoCapsFlags, recapitalizeMode);
+        } else if (code == Constants.CODE_ALPHA_FROM_NUMPAD) {
+            onPressAlphaNumpad(autoCapsFlags, recapitalizeMode);
         } else {
             mShiftKeyState.onOtherKeyPressed();
             mSymbolKeyState.onOtherKeyPressed();
@@ -462,6 +483,8 @@ public final class KeyboardState {
             setShiftLocked(!mAlphabetShiftState.isShiftLocked());
         } else if (code == Constants.CODE_SWITCH_ALPHA_SYMBOL) {
             onReleaseSymbol(withSliding, autoCapsFlags, recapitalizeMode);
+        } else if (code == Constants.CODE_ALPHA_FROM_NUMPAD) {
+            onReleaseAlphaNumpad(withSliding, autoCapsFlags, recapitalizeMode);
         }
     }
 
@@ -485,6 +508,29 @@ public final class KeyboardState {
             mPrevSymbolsKeyboardWasShifted = false;
         }
         mSymbolKeyState.onRelease();
+    }
+
+    private void onPressAlphaNumpad(final int autoCapsFlags,
+                                    final int recapitalizeMode) {
+        toggleNumpadAndAlphabet(autoCapsFlags, recapitalizeMode);
+        mAlphaNumpadKeyState.onPress();
+        mSwitchState = SWITCH_STATE_MOMENTARY_NUMPAD_AND_ALPHA;
+    }
+
+    private void onReleaseAlphaNumpad(final boolean withSliding, final int autoCapsFlags,
+                                 final int recapitalizeMode) {
+        if (mAlphaNumpadKeyState.isChording()) {
+            // Switch back to the previous keyboard mode if the user chords the mode change key and
+            // another key, then releases the mode change key.
+            toggleNumpadAndAlphabet(autoCapsFlags, recapitalizeMode);
+        } else if (!withSliding) {
+            // If the mode change key is being released without sliding, we should remember
+            // caps lock mode and reset alphabet shift state.
+            mPrevMainKeyboardWasShiftLocked = mAlphabetShiftState.isShiftLocked();
+            mAlphabetShiftState.setShiftLocked(false);
+
+        }
+        mAlphaNumpadKeyState.onRelease();
     }
 
     public void onUpdateShiftState(final int autoCapsFlags, final int recapitalizeMode) {
@@ -670,6 +716,9 @@ public final class KeyboardState {
         case SWITCH_STATE_MOMENTARY_ALPHA_SHIFT:
             setAlphabetKeyboard(autoCapsFlags, recapitalizeMode);
             break;
+        case SWITCH_STATE_MOMENTARY_NUMPAD_AND_ALPHA:
+            toggleNumpadAndAlphabet(autoCapsFlags, recapitalizeMode);
+            break;
         }
     }
 
@@ -695,6 +744,16 @@ public final class KeyboardState {
                 }
             }
             break;
+        case SWITCH_STATE_MOMENTARY_NUMPAD_AND_ALPHA:
+            if (code == Constants.CODE_ALPHA_FROM_NUMPAD) {
+                // Detected only the mode change key has been pressed, and then released.
+                if (mMode == MODE_NUMPAD) {
+                    mSwitchState = SWITCH_STATE_NUMPAD;
+                } else {
+                    mSwitchState = SWITCH_STATE_ALPHA;
+                }
+            }
+            break;
         case SWITCH_STATE_MOMENTARY_SYMBOL_AND_MORE:
             if (code == Constants.CODE_SHIFT) {
                 // Detected only the shift key has been pressed on symbol layout, and then
@@ -709,7 +768,7 @@ public final class KeyboardState {
             }
             break;
         case SWITCH_STATE_SYMBOL_BEGIN:
-            if (mMode == MODE_EMOJI || mMode == MODE_CLIPBOARD || mMode == MODE_NUMPAD) {
+            if (mMode == MODE_EMOJI || mMode == MODE_CLIPBOARD) {
                 // When in the Emoji keyboard or clipboard one, we don't want to switch back to the main layout even
                 // after the user hits an emoji letter followed by an enter or a space.
                 break;
@@ -752,8 +811,6 @@ public final class KeyboardState {
             setAlphabetKeyboard(autoCapsFlags, recapitalizeMode);
         } else if (code == Constants.CODE_NUMPAD) {
             setNumpadKeyboard();
-        } else if (code == Constants.CODE_ALPHA_FROM_NUMPAD) {
-            setAlphabetKeyboard(autoCapsFlags, recapitalizeMode);
         } else if (code == Constants.CODE_SYMBOL_FROM_NUMPAD) {
             setSymbolsKeyboard();
         } else if (code == Constants.CODE_START_ONE_HANDED_MODE) {
@@ -782,6 +839,8 @@ public final class KeyboardState {
         case SWITCH_STATE_MOMENTARY_ALPHA_AND_SYMBOL: return "MOMENTARY-ALPHA-SYMBOL";
         case SWITCH_STATE_MOMENTARY_SYMBOL_AND_MORE: return "MOMENTARY-SYMBOL-MORE";
         case SWITCH_STATE_MOMENTARY_ALPHA_SHIFT: return "MOMENTARY-ALPHA_SHIFT";
+        case SWITCH_STATE_NUMPAD: return "NUMPAD";
+        case SWITCH_STATE_MOMENTARY_NUMPAD_AND_ALPHA: return "MOMENTARY-NUMPAD-ALPHA";
         default: return null;
         }
     }


### PR DESCRIPTION
This PR implements the `SlidingKeyInput` function to the **`ABC`** key on the number pad.

Unfortunately, when "_Number row_" option is activated, and only in this case, 2 bugs persist:

1. If the letters are uppercase, the bar is on the Shift key;

2. On a specific area of the **`ABC`** key (towards the edge on the right), the keyboard has a bad behavior.

Bugs are linked to this comment: https://github.com/Helium314/openboard/pull/81#issuecomment-1685097115.