### PR TITLE
Improved behavior of the "Edit day or night colors?" dialog

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AppearanceSettingsFragment.kt
@@ -264,7 +264,9 @@ class AppearanceSettingsFragment : SubScreenFragment(), Preference.OnPreferenceC
         }
         userColorsPref = preferenceScreen.findPreference(Settings.PREF_THEME_USER)
         userColorsPref.onPreferenceClickListener = Preference.OnPreferenceClickListener { _ ->
-            if (sharedPreferences.getBoolean(Settings.PREF_THEME_DAY_NIGHT, false) && sharedPreferences.getString(Settings.PREF_CUSTOM_THEME_VARIANT, KeyboardTheme.THEME_LIGHT) == KeyboardTheme.THEME_USER)
+            if (sharedPreferences.getBoolean(Settings.PREF_THEME_DAY_NIGHT, false)
+                && sharedPreferences.getString(Settings.PREF_CUSTOM_THEME_VARIANT, KeyboardTheme.THEME_LIGHT) == KeyboardTheme.THEME_USER
+                && sharedPreferences.getString(Settings.PREF_CUSTOM_THEME_VARIANT_NIGHT, KeyboardTheme.THEME_DARK) == KeyboardTheme.THEME_USER_DARK)
                 AlertDialog.Builder(activity)
                     .setMessage(R.string.day_or_night_colors)
                     .setPositiveButton(R.string.day_or_night_night) { _, _ -> adjustColors(true)}


### PR DESCRIPTION
Currently, **_Edit day or night colors?_** dialog appears when `User-defined` theme is selected in _Theme variant_ and _Theme variant (night)_ menus. (This is quite normal)

However, this window also appears when `User-defined` theme is defined in _Theme variant_ menu but not selected in _Theme variant (night)_ menu.

This PR therefore allows this dialog to appear only when `User-defined` theme is selected in both _Theme variant_ menus.

_To notice this "bad" behavior, you must have the "Auto day/night mode" toggle on._