### PR TITLE
For Holo theme only : pinned icon follow accent color

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardAdapter.kt
@@ -13,6 +13,7 @@ import org.dslul.openboard.inputmethod.latin.ClipboardHistoryEntry
 import org.dslul.openboard.inputmethod.latin.ClipboardHistoryManager
 import org.dslul.openboard.inputmethod.latin.R
 import org.dslul.openboard.inputmethod.latin.common.Colors
+import org.dslul.openboard.inputmethod.latin.common.HoloColors
 import org.dslul.openboard.inputmethod.latin.settings.Settings
 
 class ClipboardAdapter(
@@ -67,6 +68,9 @@ class ClipboardAdapter(
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, itemTextSize)
             }
             clipboardLayoutParams.setItemProperties(view)
+            val colors = Settings.getInstance().current.mColors
+            if (colors is HoloColors)
+                pinnedIconView.colorFilter = colors.accentColorFilter
         }
 
         fun setContent(historyEntry: ClipboardHistoryEntry?) {


### PR DESCRIPTION
For Holo theme, pinned icon follow accent color:

| Before (Holo light theme) | After (Holo light theme) |
| :---: | :---: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/0e318456-8d57-4284-ada7-61a635548a40"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/2c709b9a-6b6d-4c8a-99c9-336642387323">
