### PR TITLE
Fixed gradient drawable not used for background

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
@@ -196,7 +196,7 @@ public class KeyboardView extends View {
             // todo: this should only be applied to specific keyboards, check original version for which one
             //  and actually this again is something that maybe should be done in Colors
             final Drawable keyboardBackground = mColors.getKeyboardBackground();
-            if (this instanceof MoreSuggestionsView && keyboardBackground != null)
+            if (!(this instanceof MoreSuggestionsView) && keyboardBackground != null)
                 setBackground(keyboardBackground);
             else
                 getBackground().setColorFilter(mColors.backgroundFilter);


### PR DESCRIPTION
The keyboard background for Holo themes once again uses gradient colors.

| Before | After |
| :---: | :---: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/b0878d72-28ed-40a6-b1d5-48ed6ca89eee"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/cec5c082-df22-4457-b4ed-bc5a81574f34"> |