### PR TITLE
Bar under the selected emoji category follows accent color

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -189,6 +189,8 @@ public final class EmojiPalettesView extends LinearLayout
             tabWidget.setBackgroundResource(mCategoryIndicatorDrawableResId);
             tabWidget.setLeftStripDrawable(mCategoryIndicatorBackgroundResId);
             tabWidget.setRightStripDrawable(mCategoryIndicatorBackgroundResId);
+            final Colors colors = Settings.getInstance().getCurrent().mColors;
+            tabWidget.setBackgroundColor(colors.accent);
         }
 
         mEmojiPalettesAdapter = new EmojiPalettesAdapter(mEmojiCategory, this);


### PR DESCRIPTION
In PR #121, emoji category icons follow the accent color but not the bar below when the category is selected.
This is now fixed.

| Before | After |
| :---: | :---: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/020040d4-90a8-41e6-af13-6bc8dc4dceb2"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/6a220cb2-771b-4d9d-bbb8-389ce166d181"> |