### PR TITLE
Emojis no longer have the key drawable for Holo themes

### DIFF
--- a/app/src/main/res/values/themes-holo_base.xml
+++ b/app/src/main/res/values/themes-holo_base.xml
@@ -45,7 +45,7 @@
         parent="KeyboardView.Holo"
     >
         <item name="android:background">@android:color/white</item>
-        <item name="keyBackground">@drawable/btn_keyboard_spacebar_holo_white</item>
+        <item name="keyBackground">@drawable/btn_keyboard_key_holo_white</item>
         <item name="functionalKeyBackground">@drawable/btn_keyboard_key_pressed_klp_light</item>
         <item name="spacebarBackground">@drawable/btn_keyboard_spacebar_holo_white</item>
         <item name="keyTextColor">@color/key_text_color_blue</item>


### PR DESCRIPTION
Emojis no longer have the key drawable for Holo themes.

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/68c888e1-e677-4c2b-9f60-7fe10056fead"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/2810f6dc-4189-4456-b55b-5c5875c1e774"> |