### PR TITLE
Fixed the width of "ABC" key for Holo style in clipboard view

### DIFF
--- a/app/src/main/res/layout/clipboard_history_view.xml
+++ b/app/src/main/res/layout/clipboard_history_view.xml
@@ -42,7 +42,9 @@
                 android:layout_marginTop="1dp"
                 android:layout_marginEnd="1dp"
                 android:layout_gravity="start|center_vertical"
-                android:paddingHorizontal="12dp"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:drawablePadding="12dp"
                 android:gravity="center"
                 android:hapticFeedbackEnabled="false"
                 android:soundEffectsEnabled="false" />


### PR DESCRIPTION
In the clipboard view, the "ABC" key uses the drawable for the Holo style. The `padding` parameter therefore needs to be written differently to have an identical key between the Material style and the Holo style.
Moreover, as you can see in screenshots below, "Material" style isn't impacted by this modification.

| Before (Holo style) | After (Holo style) |
| :------: | :----: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/9401e449-9b36-4e5f-8217-7f2e13dac8b3"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/0eb5a8c4-9ada-4e75-8f82-ea5b4fc7b126"> |
| Before (Material style) | After (Material style) |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/7abbed52-4995-4234-b04e-cb47c881784a"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/75047db6-339d-48fc-88a4-7ac3fe282bda"> |
