### PR TITLE
For Holo style: added 3 dots missing for some functional keys

### DIFF
--- a/app/src/main/res/xml/row_symbols4.xml
+++ b/app/src/main/res/xml/row_symbols4.xml
@@ -30,5 +30,6 @@
     <!-- U+2026: "…" HORIZONTAL ELLIPSIS -->
     <Key
         latin:keySpec="."
-        latin:moreKeys="&#x2026;" />
+        latin:moreKeys="&#x2026;"
+        latin:keyLabelFlags="hasPopupHint" />
 </merge>

--- a/app/src/main/res/xml/row_symbols_shift4.xml
+++ b/app/src/main/res/xml/row_symbols_shift4.xml
@@ -31,5 +31,6 @@
     <!-- U+2026: "…" HORIZONTAL ELLIPSIS -->
     <Key
         latin:keySpec="."
-        latin:moreKeys="&#x2026;" />
+        latin:moreKeys="&#x2026;"
+        latin:keyLabelFlags="hasPopupHint" />
 </merge>

--- a/app/src/main/res/xml/rows_numpad.xml
+++ b/app/src/main/res/xml/rows_numpad.xml
@@ -20,6 +20,7 @@
             latin:additionalMoreKeys="&#40;,&#60;,&#177;"
             latin:backgroundType="functional"
             latin:keyActionFlags="noKeyPreview"
+            latin:keyLabelFlags="hasPopupHint"
             latin:keyWidth="15%p" />
         <Key
             latin:keySpec="1"
@@ -36,6 +37,7 @@
             latin:keyStyle="currencyHintStyle"
             latin:backgroundType="functional"
             latin:keyActionFlags="noKeyPreview"
+            latin:keyLabelFlags="hasPopupHint"
             latin:keyWidth="fillRight" />
     </Row>
     <!-- Second row -->
@@ -50,6 +52,7 @@
             latin:additionalMoreKeys="&#41;,&#62;,&#126;"
             latin:backgroundType="functional"
             latin:keyActionFlags="noKeyPreview"
+            latin:keyLabelFlags="hasPopupHint"
             latin:keyWidth="15%p" />
         <Key
             latin:keySpec="4"
@@ -80,6 +83,7 @@
             latin:additionalMoreKeys="&#47;,&#215;,&#247;"
             latin:backgroundType="functional"
             latin:keyActionFlags="noKeyPreview"
+            latin:keyLabelFlags="hasPopupHint"
             latin:keyWidth="15%p" />
         <Key
             latin:keySpec="7"
@@ -102,10 +106,10 @@
         <!-- &#44; "," COMMA SIGN -->
         <Key
             latin:keySpec="&#44;"
-            latin:keyLabelFlags="hasPopupHint"
             latin:additionalMoreKeys="!text/keyspec_clipboard_normal_key,!text/keyspec_emoji_normal_key,!text/keyspec_language_switch,!text/keyspec_settings"
             latin:backgroundType="functional"
             latin:keyActionFlags="noKeyPreview"
+            latin:keyLabelFlags="hasPopupHint"
             latin:keyWidth="10%p" />
         <Key
             latin:keyStyle="symbolNumpadKeyStyle"
@@ -136,6 +140,7 @@
             latin:additionalMoreKeys="&#58;,&#8230;,&#59;,&#8734;,&#960;,&#8730;,&#176;,&#94;"
             latin:backgroundType="functional"
             latin:keyActionFlags="noKeyPreview"
+            latin:keyLabelFlags="hasPopupHint"
             latin:keyWidth="10%p" />
         <Key
             latin:keyStyle="enterKeyStyle"


### PR DESCRIPTION
This PR adds the missing 3 dots for some functional keys.
Only applies to Holo style.

| Before | After |
| :------: | :-----: |
| <img width=300 src="https://github.com/Helium314/openboard/assets/139015663/68f3f9b7-2c2e-464c-b5a2-5538d55095dd"> | <img width=300 src="https://github.com/Helium314/openboard/assets/139015663/4b148281-eebe-4c28-958d-21900834f366"> |