### PR TITLE
Comma pop-up for Numpad in portrait mode is the same as for symbol view

### DIFF
--- a/app/src/main/res/xml-land/rows_numpad.xml
+++ b/app/src/main/res/xml-land/rows_numpad.xml
@@ -172,7 +172,7 @@
         <!-- &#44; "," COMMA SIGN -->
         <Key
             latin:keySpec="&#44;"
-            latin:additionalMoreKeys="!text/keyspec_clipboard_normal_key,!text/keyspec_emoji_normal_key,!text/keyspec_language_switch,!text/keyspec_settings"
+            latin:additionalMoreKeys="!text/keyspec_clipboard_normal_key,!text/keyspec_emoji_normal_key,!text/keyspec_language_switch,!text/keyspec_start_onehanded_mode,!text/keyspec_settings"
             latin:keyActionFlags="noKeyPreview" />
         <Key
             latin:keySpec="0"

--- a/app/src/main/res/xml/rows_numpad.xml
+++ b/app/src/main/res/xml/rows_numpad.xml
@@ -106,10 +106,8 @@
         <!-- &#44; "," COMMA SIGN -->
         <Key
             latin:keySpec="&#44;"
-            latin:additionalMoreKeys="!text/keyspec_clipboard_normal_key,!text/keyspec_emoji_normal_key,!text/keyspec_language_switch,!text/keyspec_settings"
-            latin:backgroundType="functional"
+            latin:keyStyle="settingsMoreKeysStyle"
             latin:keyActionFlags="noKeyPreview"
-            latin:keyLabelFlags="hasPopupHint"
             latin:keyWidth="10%p" />
         <Key
             latin:keyStyle="symbolNumpadKeyStyle"


### PR DESCRIPTION
The comma key on the numpad is now identical to the comma key on the symbol keyboard.

In landscape mode, the comma pop-up contains all keys, as there is no style for this particular key