### PR TITLE
For Holo style: added 3 dots missing for key style less/greater

### DIFF
--- a/app/src/main/res/xml/key_styles_less_greater.xml
+++ b/app/src/main/res/xml/key_styles_less_greater.xml
@@ -31,11 +31,13 @@
                 latin:styleName="lessKeyStyle"
                 latin:keySpec="!text/keyspec_left_double_angle_quote"
                 latin:backgroundType="functional"
+                latin:keyLabelFlags="hasPopupHint"
                 latin:moreKeys="!text/morekeys_less_than" />
             <key-style
                 latin:styleName="greaterKeyStyle"
                 latin:keySpec="!text/keyspec_right_double_angle_quote"
                 latin:backgroundType="functional"
+                latin:keyLabelFlags="hasPopupHint"
                 latin:moreKeys="!text/morekeys_greater_than" />
         </case>
         <default>
@@ -43,11 +45,13 @@
                 latin:styleName="lessKeyStyle"
                 latin:keySpec="!text/keyspec_less_than"
                 latin:backgroundType="functional"
+                latin:keyLabelFlags="hasPopupHint"
                 latin:moreKeys="!text/morekeys_less_than" />
             <key-style
                 latin:styleName="greaterKeyStyle"
                 latin:keySpec="!text/keyspec_greater_than"
                 latin:backgroundType="functional"
+                latin:keyLabelFlags="hasPopupHint"
                 latin:moreKeys="!text/morekeys_greater_than" />
         </default>
     </switch>

--- a/app/src/main/res/xml/row_symbols4.xml
+++ b/app/src/main/res/xml/row_symbols4.xml
@@ -21,8 +21,7 @@
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <Key
         latin:keySpec="!text/keyspec_comma"
-        latin:keyStyle="settingsMoreKeysStyle"
-        latin:keyLabelFlags="hasPopupHint" />
+        latin:keyStyle="settingsMoreKeysStyle" />
     <Key
         latin:keyStyle="numpadKeyStyle" />
     <include

--- a/app/src/main/res/xml/row_symbols_shift4.xml
+++ b/app/src/main/res/xml/row_symbols_shift4.xml
@@ -22,8 +22,7 @@
         latin:keyboardLayout="@xml/key_styles_less_greater" />
     <Key
         latin:keySpec="!text/keyspec_comma"
-        latin:keyStyle="settingsMoreKeysStyle"
-        latin:keyLabelFlags="hasPopupHint" />
+        latin:keyStyle="settingsMoreKeysStyle" />
     <Key
         latin:keyStyle="lessKeyStyle" />
     <include


### PR DESCRIPTION
3 dots are added to the key style less/greater for the Holo style, as these are functional keys.

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/f65a1b50-1a2c-4041-828f-dcc3e7c7b7ae"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/844e5916-0832-4779-ac79-52b7387765dc"> |

Moreover, "hasPopupHint" parameter has been removed from the row_symbols4.xml and row_symbols_shift4.xml files as it's already defined in "settingsMoreKeysStyle".
