### PR TITLE
Allow setting a background image

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputView.java
@@ -17,6 +17,7 @@
 package org.dslul.openboard.inputmethod.latin;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -25,8 +26,11 @@ import android.widget.FrameLayout;
 
 import org.dslul.openboard.inputmethod.accessibility.AccessibilityUtils;
 import org.dslul.openboard.inputmethod.keyboard.MainKeyboardView;
+import org.dslul.openboard.inputmethod.latin.settings.Settings;
 import org.dslul.openboard.inputmethod.latin.suggestions.MoreSuggestionsView;
 import org.dslul.openboard.inputmethod.latin.suggestions.SuggestionStripView;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class InputView extends FrameLayout {
     private final Rect mInputViewRect = new Rect();
@@ -49,7 +53,16 @@ public final class InputView extends FrameLayout {
                 mMainKeyboardView, suggestionStripView);
         mMoreSuggestionsViewCanceler = new MoreSuggestionsViewCanceler(
                 mMainKeyboardView, suggestionStripView);
-    }
+/*        final AtomicBoolean doIt = new AtomicBoolean(true);
+        getViewTreeObserver().addOnGlobalLayoutListener(() -> {
+            // todo: not working, uses full screen size
+            if (doIt.get()) {
+                setBackgroundColor(Color.WHITE);
+                Settings.getInstance().getCurrent().mColors.setKeyboardBackground(this);
+                doIt.set(false);
+            }
+        });
+*/    }
 
     public void setKeyboardTopPadding(final int keyboardTopPadding) {
         mKeyboardTopPaddingForwarder.setKeyboardTopPadding(keyboardTopPadding);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/KeyboardWrapperView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/KeyboardWrapperView.kt
@@ -8,6 +8,7 @@ import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageButton
+import androidx.core.view.doOnNextLayout
 import org.dslul.openboard.inputmethod.keyboard.KeyboardActionListener
 import org.dslul.openboard.inputmethod.latin.common.BackgroundType
 import org.dslul.openboard.inputmethod.latin.common.Constants
@@ -60,8 +61,13 @@ class KeyboardWrapperView @JvmOverloads constructor(
         switchOneHandedModeBtn.colorFilter = colors.keyTextFilter
         colors.setBackgroundColor(stopOneHandedModeBtn.background, BackgroundType.BACKGROUND)
         colors.setBackgroundColor(switchOneHandedModeBtn.background, BackgroundType.BACKGROUND)
-        setBackgroundColor(Color.WHITE) // otherwise background might be null
-        colors.setKeyboardBackground(this)
+
+        // necessary so view has a height when Colors.setKeyboardBackground is called
+        // this is important because BitmapDrawable doesn't scale
+        doOnNextLayout {
+            setBackgroundColor(Color.WHITE) // otherwise background might be null
+            colors.setKeyboardBackground(this)
+        }
     }
 
     @SuppressLint("RtlHardcoded")

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.kt
@@ -5,12 +5,15 @@ import android.content.res.TypedArray
 import android.graphics.Color
 import android.graphics.ColorFilter
 import android.graphics.PorterDuff
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.graphics.drawable.toBitmap
 import org.dslul.openboard.inputmethod.keyboard.KeyboardTheme.THEME_STYLE_HOLO
 import org.dslul.openboard.inputmethod.keyboard.KeyboardTheme.THEME_STYLE_MATERIAL
 import org.dslul.openboard.inputmethod.keyboard.MainKeyboardView
@@ -18,6 +21,7 @@ import org.dslul.openboard.inputmethod.keyboard.MoreKeysKeyboardView
 import org.dslul.openboard.inputmethod.keyboard.clipboard.ClipboardHistoryView
 import org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPageKeyboardView
 import org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView
+import org.dslul.openboard.inputmethod.latin.InputView
 import org.dslul.openboard.inputmethod.latin.KeyboardWrapperView
 import org.dslul.openboard.inputmethod.latin.R
 import org.dslul.openboard.inputmethod.latin.suggestions.MoreSuggestionsView
@@ -175,13 +179,27 @@ class Colors (
         when (view) {
             is MoreSuggestionsView -> view.background.colorFilter = backgroundFilter
             is MoreKeysKeyboardView -> view.background.colorFilter = adjustedBackgroundFilter
-            is SuggestionStripView -> setBackgroundColor(view.background, BackgroundType.SUGGESTION)
+            is SuggestionStripView -> setBackgroundColor(view.background, BackgroundType.SUGGESTION) // todo: maybe change?
             is EmojiPageKeyboardView, // to make EmojiPalettesView background visible, which does not scroll
             is MainKeyboardView -> view.setBackgroundColor(Color.TRANSPARENT) // otherwise causes issues with wrapper view when using one-handed mode
-            is KeyboardWrapperView, is EmojiPalettesView, is ClipboardHistoryView -> {
-                if (keyboardBackground != null) view.background = keyboardBackground
-                else view.background.colorFilter = backgroundFilter
+            is KeyboardWrapperView -> {
+                val bg = ContextCompat.getDrawable(view.context, R.drawable.setup_welcome_image)!!
+                // suggestion strip height: config_suggestions_strip_height
+                view.background = BitmapDrawable(bg.toBitmap(height = view.height, width = view.width))
             }
+            is EmojiPalettesView, is ClipboardHistoryView -> {
+                // todo: adjust size
+                view.background = ContextCompat.getDrawable(view.context, R.drawable.setup_welcome_image)
+            }
+
+            /* this is not working, sets the image on the full screen. maybe mInputViewRect helps
+            is EmojiPalettesView, is ClipboardHistoryView, is KeyboardWrapperView -> view.setBackgroundColor(Color.TRANSPARENT)
+            is InputView -> {
+                val bg = ContextCompat.getDrawable(view.context, R.drawable.setup_welcome_image)!!
+                view.background = BitmapDrawable(bg.toBitmap(height = view.height, width = view.width))
+            }
+            */
+
             else -> view.background.colorFilter = backgroundFilter
         }
     }


### PR DESCRIPTION
The goal is to allow supplying an image that is used as keyboard background.

Currently, the setup wizard image is used, simply because it's available and the exact choice should not matter at this point.

One very important question is where to set the background image:
* `InputView` (assuming the full-height glitch gets fixed): then the other views (`KeyboardWrapperView`, `EmojiPalettesView`, `ClipboardHistoryView`) will be transparent. Probably the `SuggestionStripView` background too, but I didn't test.
This can only work if all 3 views use the same height, which also implies the suggestion strip must always be shown (even if not used). So a constant keyboard height would need to be ensured first (considering number row and height scale).
* `KeyboardWrapperView`, `EmojiPalettesView`, and `ClipboardHistoryView`: would necessitate fewer changes, but then the image will have different height for `KeyboardWrapperView` than for the others. The choice is to either cut or stretch the images, which one is preferrable may depend on the image.
With this approach it should be considered that `KeyboardWrapperView` only starts below `SuggestionStripView`.

Later:
* enable alpha slider for color picker (for transparent keys)
* deal with suggested word views (could be partially transparent when pressed)

(maybe I will not continue working on this PR, but if someone wants to work on it, they can continue from here)