### PR TITLE
Improve capitalization for special cases

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -49,6 +49,8 @@ import org.dslul.openboard.inputmethod.latin.utils.RecapitalizeStatus;
 import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 import org.dslul.openboard.inputmethod.latin.utils.ScriptUtils;
 
+import java.util.Locale;
+
 public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private static final String TAG = KeyboardSwitcher.class.getSimpleName();
 
@@ -592,5 +594,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
 
     public void switchToSubtype(InputMethodSubtype subtype) {
         mLatinIME.switchToSubtype(subtype);
+    }
+
+    public Locale getCurrentDictionaryLocale() {
+        return mLatinIME.getCurrentDictionaryLocale();
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/DictionaryFacilitatorImpl.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/DictionaryFacilitatorImpl.java
@@ -622,16 +622,14 @@ public class DictionaryFacilitatorImpl implements DictionaryFacilitator {
         boolean[] validWordForDictionary; // store results to avoid unnecessary duplicate lookups
         if (mDictionaryGroups.size() > 1 && words.length == 1) {
             validWordForDictionary = new boolean[mDictionaryGroups.size()];
-            // if suggestion was auto-capitalized, check against both the suggestion and the de-capitalized suggestion
-            final String decapitalizedSuggestion;
-            if (wasAutoCapitalized)
-                decapitalizedSuggestion = suggestion.substring(0, 1).toLowerCase() + suggestion.substring(1);
-            else
-                decapitalizedSuggestion = suggestion;
             for (int i = 0; i < mDictionaryGroups.size(); i ++) {
                 final DictionaryGroup dictionaryGroup = mDictionaryGroups.get(i);
                 final boolean isValidWord = isValidWord(suggestion, ALL_DICTIONARY_TYPES, dictionaryGroup);
-                if (isValidWord || (wasAutoCapitalized && isValidWord(decapitalizedSuggestion, ALL_DICTIONARY_TYPES, dictionaryGroup)))
+                // if suggestion was auto-capitalized, check against both the suggestion and the de-capitalized suggestion
+                if (isValidWord
+                        || (wasAutoCapitalized
+                        && isValidWord(StringUtils.decapitalizeFirstCodePoint(suggestion, dictionaryGroup.mLocale), ALL_DICTIONARY_TYPES, dictionaryGroup)
+                ))
                     dictionaryGroup.increaseConfidence();
                 else dictionaryGroup.decreaseConfidence();
                 validWordForDictionary[i] = isValidWord;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -767,6 +767,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
                 this /* DictionaryInitializationListener */);
     }
 
+    public Locale getCurrentDictionaryLocale() {
+        return mDictionaryFacilitator.getCurrentLocale();
+    }
+
     @Override
     public void onDestroy() {
         mClipboardHistoryManager.onDestroy();

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/Suggest.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/Suggest.java
@@ -111,19 +111,19 @@ public final class Suggest {
             final int trailingSingleQuotesCount, final Locale defaultLocale) {
         final boolean shouldMakeSuggestionsAllUpperCase = wordComposer.isAllUpperCase()
                 && !wordComposer.isResumed();
-        final boolean isOnlyFirstCharCapitalized =
-                wordComposer.isOrWillBeOnlyFirstCharCapitalized();
+        final boolean isOnlyFirstCodePointCapitalized =
+                wordComposer.isOrWillBeOnlyFirstCodePointCapitalized();
 
         final ArrayList<SuggestedWordInfo> suggestionsContainer = new ArrayList<>(results);
         final int suggestionsCount = suggestionsContainer.size();
-        if (isOnlyFirstCharCapitalized || shouldMakeSuggestionsAllUpperCase
+        if (isOnlyFirstCodePointCapitalized || shouldMakeSuggestionsAllUpperCase
                 || 0 != trailingSingleQuotesCount) {
             for (int i = 0; i < suggestionsCount; ++i) {
                 final SuggestedWordInfo wordInfo = suggestionsContainer.get(i);
                 final Locale wordLocale = wordInfo.mSourceDict.mLocale;
                 final SuggestedWordInfo transformedWordInfo = getTransformedSuggestedWordInfo(
                         wordInfo, null == wordLocale ? defaultLocale : wordLocale,
-                        shouldMakeSuggestionsAllUpperCase, isOnlyFirstCharCapitalized,
+                        shouldMakeSuggestionsAllUpperCase, isOnlyFirstCodePointCapitalized,
                         trailingSingleQuotesCount);
                 suggestionsContainer.set(i, transformedWordInfo);
             }
@@ -437,7 +437,7 @@ public final class Suggest {
         final ArrayList<SuggestedWordInfo> suggestionsContainer =
                 new ArrayList<>(suggestionResults);
         final int suggestionsCount = suggestionsContainer.size();
-        final boolean isFirstCharCapitalized = wordComposer.wasShiftedNoLock();
+        final boolean isFirstCharCapitalized = wordComposer.wasShiftedNoLock(); // todo: this really only affects first codepoint -> what do?
         final boolean isAllUpperCase = wordComposer.isAllUpperCase();
         if (isFirstCharCapitalized || isAllUpperCase) {
             for (int i = 0; i < suggestionsCount; ++i) {
@@ -547,11 +547,11 @@ public final class Suggest {
 
     /* package for test */ static SuggestedWordInfo getTransformedSuggestedWordInfo(
             final SuggestedWordInfo wordInfo, final Locale locale, final boolean isAllUpperCase,
-            final boolean isOnlyFirstCharCapitalized, final int trailingSingleQuotesCount) {
+            final boolean isOnlyFirstCodePointCapitalized, final int trailingSingleQuotesCount) {
         final StringBuilder sb = new StringBuilder(wordInfo.mWord.length());
         if (isAllUpperCase) {
             sb.append(wordInfo.mWord.toUpperCase(locale));
-        } else if (isOnlyFirstCharCapitalized) {
+        } else if (isOnlyFirstCodePointCapitalized) {
             sb.append(StringUtils.capitalizeFirstCodePoint(wordInfo.mWord, locale));
         } else {
             sb.append(wordInfo.mWord);


### PR DESCRIPTION
Goal is fixing quirks around proper double-letter capitalization, currently focused on Dutch _IJ_.
The current way of treating this may lead to spell check and suggestion issues in some cases.

Changes in here are untested, and likely it will be necessary to fix input coming from auto-shift (capitalizes first letter only)).