### PR TITLE
Add support for inline autofill

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
@@ -227,6 +227,15 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         mStripVisibilityGroup.showSuggestionsStrip();
     }
 
+    public void addSuggestionView(final View view) {
+        // this still doesn't look right, maybe check how mLayoutHelper does it
+        if (mSuggestionsStrip.getChildCount() > 0) {
+            final View divider = LayoutInflater.from(getContext()).inflate(R.layout.suggestion_divider, null);
+            mSuggestionsStrip.addView(divider);
+        }
+        mSuggestionsStrip.addView(view);
+    }
+
     public void setMoreSuggestionsHeight(final int remainingHeight) {
         mLayoutHelper.setMoreSuggestionsHeight(remainingHeight);
     }

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -122,7 +122,8 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
         android:settingsActivity="org.dslul.openboard.inputmethod.latin.settings.SettingsActivity"
         android:isDefault="@bool/im_is_default"
-        android:supportsSwitchingToNextInputMethod="true">
+        android:supportsSwitchingToNextInputMethod="true"
+        android:supportsInlineSuggestions="true">
     <subtype android:icon="@drawable/ic_ime_switcher_dark"
             android:label="@string/subtype_generic"
             android:subtypeId="0xc9194f97"


### PR DESCRIPTION
I tried implementing this according to documentation and a [guide](https://developer.android.com/guide/topics/text/ime-autofill), but since I need Android 11 for testing, I will not be able to actually test this and thus will not continue working on this feature.

If anyone with a less antique phone wants to pick up and continue the work it would be great.
In best case, only proper formatting for the views would be necessary, but this can still be very tricky.