### PR TITLE
Holo style: set color of default number pad spacebar icon

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
@@ -619,6 +619,9 @@ public class KeyboardView extends View {
         } else if (this instanceof MoreKeysKeyboardView) {
             // set color filter for long press comma key, should not trigger anywhere else
             icon.setColorFilter(mColors.getKeyTextFilter());
+        } else if (key.getCode() == Constants.CODE_SPACE) {
+            // set color of default number pad space bar icon for Holo style
+            icon.setColorFilter(mColors.getKeyTextFilter());
         }
     }
 


### PR DESCRIPTION
**Holo style only because Material style is not affected.**

This PR corrects the color of the space bar icon for the default number pad (the one that appears when you want to register a phone number, for example).

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/6230c8d0-d0d5-493f-a54c-04349b4848cb"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/d1ef26b8-5035-466b-930b-6f5544878cea"> |

_Tested on Huawei phone with Android 10_