### PR TITLE
Update ndk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ android {
         abortOnError false
     }
 
-    ndkVersion '23.2.8568313'
+    ndkVersion '25.2.9519653'
     androidResources {
         noCompress 'main.dict'
         noCompress 'empty.dict'

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -27,7 +27,7 @@ LATIN_IME_SRC_DIR := src
 
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(LATIN_IME_SRC_DIR)
 
-LOCAL_CFLAGS += -Werror -Wall -Wextra -Weffc++ -Wformat=2 -Wcast-qual -Wcast-align \
+LOCAL_CFLAGS += -Wall -Wextra -Weffc++ -Wformat=2 -Wcast-qual -Wcast-align \
     -Wwrite-strings -Wfloat-equal -Wpointer-arith -Winit-self -Wredundant-decls \
     -Woverloaded-virtual -Wsign-promo -Wno-system-headers
 


### PR DESCRIPTION
Update to latest LTS NDK and do not fail on warnings.  Tested on Android 7.1.