### PR TITLE
Update targets to java 17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,14 +63,14 @@ android {
             includeAndroidResources = true
         }
     }
-    
+
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     namespace "org.dslul.openboard.inputmethod.latin"

--- a/tools/make-emoji-keys/build.gradle
+++ b/tools/make-emoji-keys/build.gradle
@@ -31,6 +31,6 @@ dependencies {
 
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }

--- a/tools/make-keyboard-text/build.gradle
+++ b/tools/make-keyboard-text/build.gradle
@@ -17,6 +17,6 @@ task makeText(type: JavaExec, dependsOn: ['jar']) {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }


### PR DESCRIPTION
The newly upgraded dependencies (gradle 8.3) now require java 17 and the java and jvm targets must both match or there will be a build failure due to lint.
