### PR TITLE
Restored pin icon color for material style

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardAdapter.kt
@@ -68,7 +68,7 @@ class ClipboardAdapter(
             }
             clipboardLayoutParams.setItemProperties(view)
             val colors = Settings.getInstance().current.mColors
-            pinnedIconView.colorFilter = colors.clipboardPinFilter
+            pinnedIconView.colorFilter = colors.accentColorFilter
         }
 
         fun setContent(historyEntry: ClipboardHistoryEntry?) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.kt
@@ -56,8 +56,6 @@ class Colors (
     val accentColorFilter: ColorFilter
     /** color filter for the white action key icons in material theme, switches to gray if necessary for contrast */
     val actionKeyIconColorFilter: ColorFilter?
-    /** color filter for the clipboard pin, used only in holo theme */
-    val clipboardPinFilter: ColorFilter?
 
     private val backgroundStateList: ColorStateList
     private val keyStateList: ColorStateList
@@ -77,12 +75,10 @@ class Colors (
             navBar = darkerBackground
             keyboardBackground = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, intArrayOf(background, darkerBackground))
             spaceBarText = keyText
-            clipboardPinFilter = accentColorFilter
         } else {
             navBar = background
             keyboardBackground = null
             spaceBarText = keyHintText
-            clipboardPinFilter = null
         }
 
         // create color filters, todo: maybe better / simplify

--- a/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
+++ b/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
@@ -4,7 +4,7 @@
     android:width="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24"  >
-    <path android:fillColor="#1972E6"
+    <path android:fillColor="#FFF"
         android:fillType="evenOdd"
         android:pathData="M16,9V4l1,0c0.55,0 1,-0.45 1,-1v0c0,-0.55 -0.45,-1 -1,-1H7C6.45,2 6,2.45 6,3v0c0,0.55 0.45,1 1,1l1,0v5c0,1.66 -1.34,3 -3,3h0v2h5.97v7l1,1l1,-1v-7H19v-2h0C17.34,12 16,10.66 16,9z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
+++ b/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
@@ -1,9 +1,10 @@
+<!-- clipart available in Android Studio, Apache License 2.0 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960">
-    <path
-        android:fillColor="#1972E6"
-        android:pathData="M640,480L720,560L720,640L520,640L520,880L480,920L440,880L440,640L240,640L240,560L320,480L320,200L280,200L280,120L680,120L680,200L640,200L640,480ZM354,560L606,560L560,514L560,200L400,200L400,514L354,560ZM480,560L480,560L480,560L480,560L480,560L480,560L480,560Z"/>
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"  >
+    <path android:fillColor="#1972E6"
+        android:fillType="evenOdd"
+        android:pathData="M16,9V4l1,0c0.55,0 1,-0.45 1,-1v0c0,-0.55 -0.45,-1 -1,-1H7C6.45,2 6,2.45 6,3v0c0,0.55 0.45,1 1,1l1,0v5c0,1.66 -1.34,3 -3,3h0v2h5.97v7l1,1l1,-1v-7H19v-2h0C17.34,12 16,10.66 16,9z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
+++ b/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
@@ -1,10 +1,9 @@
-<!-- clipart available in Android Studio, Apache License 2.0 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
     android:width="24dp"
-    android:viewportHeight="24"
-    android:viewportWidth="24"  >
-    <path android:fillColor="#1972E6"
-        android:fillType="evenOdd"
-        android:pathData="M16,9V4l1,0c0.55,0 1,-0.45 1,-1v0c0,-0.55 -0.45,-1 -1,-1H7C6.45,2 6,2.45 6,3v0c0,0.55 0.45,1 1,1l1,0v5c0,1.66 -1.34,3 -3,3h0v2h5.97v7l1,1l1,-1v-7H19v-2h0C17.34,12 16,10.66 16,9z"/>
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#1972E6"
+        android:pathData="M640,480L720,560L720,640L520,640L520,880L480,920L440,880L440,640L240,640L240,560L320,480L320,200L280,200L280,120L680,120L680,200L640,200L640,480ZM354,560L606,560L560,514L560,200L400,200L400,514L354,560ZM480,560L480,560L480,560L480,560L480,560L480,560L480,560Z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
+++ b/app/src/main/res/drawable/ic_clipboard_pin_lxx.xml
@@ -4,7 +4,7 @@
     android:width="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24"  >
-    <path android:fillColor="#FFF"
+    <path android:fillColor="#1972E6"
         android:fillType="evenOdd"
         android:pathData="M16,9V4l1,0c0.55,0 1,-0.45 1,-1v0c0,-0.55 -0.45,-1 -1,-1H7C6.45,2 6,2.45 6,3v0c0,0.55 0.45,1 1,1l1,0v5c0,1.66 -1.34,3 -3,3h0v2h5.97v7l1,1l1,-1v-7H19v-2h0C17.34,12 16,10.66 16,9z"/>
 </vector>


### PR DESCRIPTION
Restored pin icon color for material style.

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/0c258dd9-0268-4311-9a8a-56c4c7af9948"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/89203333-00df-431a-92d1-fa889ba55e5d"> |

_Tested on Huawei phone with Android 10 and Samsung tablet with Android 13_