### PR TITLE
Restored delete key color in emoji view

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -246,6 +246,7 @@ public final class EmojiPalettesView extends LinearLayout
         // deleteKey depends only on OnTouchListener.
         mDeleteKey = findViewById(R.id.emoji_keyboard_delete);
         mDeleteKey.setBackgroundResource(mFunctionalKeyBackgroundId);
+        mDeleteKey.setColorFilter(colors.getKeyTextFilter());
         mDeleteKey.setTag(Constants.CODE_DELETE);
         mDeleteKey.setOnTouchListener(mDeleteKeyOnTouchListener);
 


### PR DESCRIPTION
Restored delete key color in emoji view.

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/44be6fb7-c4da-4548-934d-091ef8f826dd"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/90d37198-f5ac-41f2-8f80-ef50061af4c7"> |

_Tested on Huawei phone with Android 10 and Samsung tablet with Android 13_