### PR TITLE
Replace color picker by new one with editable hex values

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.2.1' // includes appcompat
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.github.skydoves:colorpickerview:2.2.4'
+    implementation 'me.jfenn.ColorPickerDialog:base:0.2.2'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.12.4'
@@ -89,4 +89,8 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.9'
     testImplementation 'androidx.test:runner:1.5.2'
     testImplementation 'androidx.test:core:1.5.0'
+}
+
+repositories {
+    maven { url "https://jitpack.io" }
 }

--- a/app/src/main/res/values/preferences_styles.xml
+++ b/app/src/main/res/values/preferences_styles.xml
@@ -12,4 +12,8 @@
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/foreground_weak</item>
     </style>
+    <style name="ColorPickerDialog.Dark" parent="Theme.AppCompat.DayNight.Dialog">
+        <!-- To match with day and night themes, we have to add this style.
+        See https://github.com/fennifith/ColorPickerDialog#theming -->
+    </style>
 </resources>


### PR DESCRIPTION
Fixes #156 

<details>
<summary><b>See screenshots</b></summary>
<br>

| Day Mode | Night Mode |
| :----------: | :-------------: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/0fc08338-bc34-4f01-aa49-87f99122fcb8"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/57819cba-77e8-4499-ac08-d8ee98e80e29"> |

</details>

_Tested on Huawei phone with Android 10 and Samsung tablet with Android 13_