### PR TITLE
Expose more colors to users (only for user-defined themes)

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
@@ -135,20 +135,22 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                 final int accent = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_ACCENT_SUFFIX, false);
                 final int keyBgColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_KEYS_SUFFIX, false);
                 final int functionalKeyBgColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX, false);
-                final int spaceBarBgColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACE_BAR_SUFFIX, false);
+                final int spaceBarBgColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACEBAR_SUFFIX, false);
                 final int keyTextColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_TEXT_SUFFIX, false);
                 final int hintTextColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_HINT_TEXT_SUFFIX, false);
+                final int spaceBarTextColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACEBAR_TEXT_SUFFIX, false);
                 final int background = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_BACKGROUND_SUFFIX, false);
-                return new Colors(themeStyle, hasBorders, accent, background, keyBgColor, functionalKeyBgColor, spaceBarBgColor, keyTextColor, hintTextColor);
+                return new Colors(themeStyle, hasBorders, accent, background, keyBgColor, functionalKeyBgColor, spaceBarBgColor, keyTextColor, hintTextColor, spaceBarTextColor);
             case THEME_USER_NIGHT:
                 final int accent2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_ACCENT_SUFFIX, true);
                 final int keyBgColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_KEYS_SUFFIX, true);
                 final int functionalKeyBgColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX, true);
-                final int spaceBarBgColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACE_BAR_SUFFIX, true);
+                final int spaceBarBgColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACEBAR_SUFFIX, true);
                 final int keyTextColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_TEXT_SUFFIX, true);
                 final int hintTextColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_HINT_TEXT_SUFFIX, true);
+                final int spaceBarTextColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACEBAR_TEXT_SUFFIX, true);
                 final int background2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_BACKGROUND_SUFFIX, true);
-                return new Colors(themeStyle, hasBorders, accent2, background2, keyBgColor2, functionalKeyBgColor2, spaceBarBgColor2, keyTextColor2, hintTextColor2);
+                return new Colors(themeStyle, hasBorders, accent2, background2, keyBgColor2, functionalKeyBgColor2, spaceBarBgColor2, keyTextColor2, hintTextColor2, spaceBarTextColor2);
             case THEME_DARK:
                 return new Colors(
                         themeStyle,
@@ -160,7 +162,8 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                         Color.parseColor("#2d393f"),
                         Color.parseColor("#364248"),
                         ContextCompat.getColor(context, R.color.key_text_color_lxx_dark),
-                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_dark)
+                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_dark),
+                        ContextCompat.getColor(context, R.color.spacebar_letter_color_lxx_dark)
                 );
             case THEME_HOLO_WHITE:
                 return new Colors(
@@ -173,6 +176,7 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                         Color.parseColor("#444444"), // should be 222222, but the key drawable is already grey
                         Color.parseColor("#FFFFFF"),
                         Color.parseColor("#FFFFFF"),
+                        Color.parseColor("#282828"),
                         Color.parseColor("#282828")
                 );
             case THEME_DARKER:
@@ -185,7 +189,8 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                         ContextCompat.getColor(context, R.color.key_background_functional_lxx_dark_border),
                         ContextCompat.getColor(context, R.color.key_background_normal_lxx_dark_border),
                         ContextCompat.getColor(context, R.color.key_text_color_lxx_dark),
-                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_dark)
+                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_dark),
+                        ContextCompat.getColor(context, R.color.spacebar_letter_color_lxx_dark)
                 );
             case THEME_BLACK:
                 return new Colors(
@@ -197,7 +202,8 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                         ContextCompat.getColor(context, R.color.background_amoled_dark),
                         ContextCompat.getColor(context, R.color.background_amoled_dark),
                         ContextCompat.getColor(context, R.color.key_text_color_lxx_dark),
-                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_dark)
+                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_dark),
+                        ContextCompat.getColor(context, R.color.spacebar_letter_color_lxx_dark)
                 );
             case THEME_LIGHT:
             default:
@@ -210,7 +216,8 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                         ContextCompat.getColor(context, R.color.key_background_functional_lxx_light_border),
                         ContextCompat.getColor(context, R.color.key_background_normal_lxx_light_border),
                         ContextCompat.getColor(context, R.color.key_text_color_lxx_light),
-                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_light)
+                        ContextCompat.getColor(context, R.color.key_hint_letter_color_lxx_light),
+                        ContextCompat.getColor(context, R.color.spacebar_letter_color_lxx_light)
                 );
         }
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
@@ -134,17 +134,21 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
             case THEME_USER:
                 final int accent = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_ACCENT_SUFFIX, false);
                 final int keyBgColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_KEYS_SUFFIX, false);
+                final int functionalKeyBgColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX, false);
+                final int spaceBarBgColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACE_BAR_SUFFIX, false);
                 final int keyTextColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_TEXT_SUFFIX, false);
                 final int hintTextColor = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_HINT_TEXT_SUFFIX, false);
                 final int background = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_BACKGROUND_SUFFIX, false);
-                return new Colors(themeStyle, hasBorders, accent, background, keyBgColor, ColorUtilKt.brightenOrDarken(keyBgColor, true), keyBgColor, keyTextColor, hintTextColor);
+                return new Colors(themeStyle, hasBorders, accent, background, keyBgColor, functionalKeyBgColor, spaceBarBgColor, keyTextColor, hintTextColor);
             case THEME_USER_NIGHT:
                 final int accent2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_ACCENT_SUFFIX, true);
                 final int keyBgColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_KEYS_SUFFIX, true);
+                final int functionalKeyBgColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX, true);
+                final int spaceBarBgColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_SPACE_BAR_SUFFIX, true);
                 final int keyTextColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_TEXT_SUFFIX, true);
                 final int hintTextColor2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_HINT_TEXT_SUFFIX, true);
                 final int background2 = Settings.readUserColor(prefs, context, Settings.PREF_COLOR_BACKGROUND_SUFFIX, true);
-                return new Colors(themeStyle, hasBorders, accent2, background2, keyBgColor2, ColorUtilKt.brightenOrDarken(keyBgColor2, true), keyBgColor2, keyTextColor2, hintTextColor2);
+                return new Colors(themeStyle, hasBorders, accent2, background2, keyBgColor2, functionalKeyBgColor2, spaceBarBgColor2, keyTextColor2, hintTextColor2);
             case THEME_DARK:
                 return new Colors(
                         themeStyle,

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/common/Colors.kt
@@ -35,7 +35,8 @@ class Colors (
     val functionalKey: Int,
     val spaceBar: Int,
     val keyText: Int,
-    val keyHintText: Int
+    val keyHintText: Int,
+    val spaceBarText: Int
 ) {
     val navBar: Int
     /** brightened or darkened variant of [background], to be used if exact background color would be
@@ -45,7 +46,6 @@ class Colors (
     val doubleAdjustedBackground: Int
     /** brightened or darkened variant of [keyText] */
     val adjustedKeyText: Int
-    val spaceBarText: Int
 
     val backgroundFilter: ColorFilter
     val adjustedBackgroundFilter: ColorFilter
@@ -74,11 +74,9 @@ class Colors (
             val darkerBackground = adjustLuminosityAndKeepAlpha(background, -0.2f)
             navBar = darkerBackground
             keyboardBackground = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, intArrayOf(background, darkerBackground))
-            spaceBarText = keyText
         } else {
             navBar = background
             keyboardBackground = null
-            spaceBarText = keyHintText
         }
 
         // create color filters

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
@@ -34,9 +34,10 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
         Settings.PREF_COLOR_BACKGROUND_SUFFIX,
         Settings.PREF_COLOR_KEYS_SUFFIX,
         Settings.PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX,
-        Settings.PREF_COLOR_SPACE_BAR_SUFFIX,
+        Settings.PREF_COLOR_SPACEBAR_SUFFIX,
         Settings.PREF_COLOR_TEXT_SUFFIX,
         Settings.PREF_COLOR_HINT_TEXT_SUFFIX,
+        Settings.PREF_COLOR_SPACEBAR_TEXT_SUFFIX,
         Settings.PREF_COLOR_ACCENT_SUFFIX,
     )
 
@@ -68,9 +69,10 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
             R.string.select_color_background,
             R.string.select_color_key_background,
             R.string.select_color_functional_key_background,
-            R.string.select_color_space_bar_background,
+            R.string.select_color_spacebar_background,
             R.string.select_color_key,
             R.string.select_color_key_hint,
+            R.string.select_color_spacebar_text,
             R.string.select_color_accent,
         ).map { requireContext().getString(it) }
         val prefPrefix = if (isNight) Settings.PREF_THEME_USER_COLOR_NIGHT_PREFIX else Settings.PREF_THEME_USER_COLOR_PREFIX

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
@@ -33,6 +33,8 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
     private val colorPrefs = listOf(
         Settings.PREF_COLOR_BACKGROUND_SUFFIX,
         Settings.PREF_COLOR_KEYS_SUFFIX,
+        Settings.PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX,
+        Settings.PREF_COLOR_SPACE_BAR_SUFFIX,
         Settings.PREF_COLOR_TEXT_SUFFIX,
         Settings.PREF_COLOR_HINT_TEXT_SUFFIX,
         Settings.PREF_COLOR_ACCENT_SUFFIX,
@@ -65,6 +67,8 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
         val colorPrefNames = listOf(
             R.string.select_color_background,
             R.string.select_color_key_background,
+            R.string.select_color_functional_key_background,
+            R.string.select_color_space_bar_background,
             R.string.select_color_key,
             R.string.select_color_key_hint,
             R.string.select_color_accent,

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -62,6 +62,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_THEME_USER_COLOR_PREFIX = "theme_color_";
     public static final String PREF_THEME_USER_COLOR_NIGHT_PREFIX = "theme_dark_color_";
     public static final String PREF_COLOR_KEYS_SUFFIX = "keys";
+    public static final String PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX = "functional_keys";
+    public static final String PREF_COLOR_SPACE_BAR_SUFFIX = "space_bar";
     public static final String PREF_COLOR_ACCENT_SUFFIX = "accent";
     public static final String PREF_COLOR_TEXT_SUFFIX = "text";
     public static final String PREF_COLOR_HINT_TEXT_SUFFIX = "hint_text";
@@ -514,6 +516,10 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
                 else return Color.LTGRAY;
             case PREF_COLOR_KEYS_SUFFIX:
                 return ColorUtilKt.brightenOrDarken(readUserColor(prefs, context, PREF_COLOR_BACKGROUND_SUFFIX, isNight), isNight);
+            case PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX:
+                return ColorUtilKt.brightenOrDarken(readUserColor(prefs, context, PREF_COLOR_KEYS_SUFFIX, isNight), true);
+            case PREF_COLOR_SPACE_BAR_SUFFIX:
+                return readUserColor(prefs, context, PREF_COLOR_KEYS_SUFFIX, isNight);
             case PREF_COLOR_BACKGROUND_SUFFIX:
             default:
                 return ContextCompat.getColor(getDayNightContext(context, isNight), R.color.keyboard_background);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -514,7 +514,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
                 else return Color.WHITE;
             case PREF_COLOR_HINT_TEXT_SUFFIX:
                 if (ColorUtilKt.isBrightColor(readUserColor(prefs, context, PREF_COLOR_KEYS_SUFFIX, isNight))) return Color.DKGRAY;
-                else return Color.LTGRAY;
+                else return readUserColor(prefs, context, PREF_COLOR_TEXT_SUFFIX, isNight);
             case PREF_COLOR_KEYS_SUFFIX:
                 return ColorUtilKt.brightenOrDarken(readUserColor(prefs, context, PREF_COLOR_BACKGROUND_SUFFIX, isNight), isNight);
             case PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX:
@@ -523,7 +523,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
                 return readUserColor(prefs, context, PREF_COLOR_KEYS_SUFFIX, isNight);
             case PREF_COLOR_SPACEBAR_TEXT_SUFFIX:
                 if (ColorUtilKt.isBrightColor(readUserColor(prefs, context, PREF_COLOR_SPACEBAR_SUFFIX, isNight))) return Color.DKGRAY;
-                else return Color.LTGRAY;
+                else return readUserColor(prefs, context, PREF_COLOR_TEXT_SUFFIX, isNight);
             case PREF_COLOR_BACKGROUND_SUFFIX:
             default:
                 return ContextCompat.getColor(getDayNightContext(context, isNight), R.color.keyboard_background);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -63,7 +63,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_THEME_USER_COLOR_NIGHT_PREFIX = "theme_dark_color_";
     public static final String PREF_COLOR_KEYS_SUFFIX = "keys";
     public static final String PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX = "functional_keys";
-    public static final String PREF_COLOR_SPACE_BAR_SUFFIX = "space_bar";
+    public static final String PREF_COLOR_SPACEBAR_SUFFIX = "spacebar";
+    public static final String PREF_COLOR_SPACEBAR_TEXT_SUFFIX = "spacebar_text";
     public static final String PREF_COLOR_ACCENT_SUFFIX = "accent";
     public static final String PREF_COLOR_TEXT_SUFFIX = "text";
     public static final String PREF_COLOR_HINT_TEXT_SUFFIX = "hint_text";
@@ -518,8 +519,11 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
                 return ColorUtilKt.brightenOrDarken(readUserColor(prefs, context, PREF_COLOR_BACKGROUND_SUFFIX, isNight), isNight);
             case PREF_COLOR_FUNCTIONAL_KEYS_SUFFIX:
                 return ColorUtilKt.brightenOrDarken(readUserColor(prefs, context, PREF_COLOR_KEYS_SUFFIX, isNight), true);
-            case PREF_COLOR_SPACE_BAR_SUFFIX:
+            case PREF_COLOR_SPACEBAR_SUFFIX:
                 return readUserColor(prefs, context, PREF_COLOR_KEYS_SUFFIX, isNight);
+            case PREF_COLOR_SPACEBAR_TEXT_SUFFIX:
+                if (ColorUtilKt.isBrightColor(readUserColor(prefs, context, PREF_COLOR_SPACEBAR_SUFFIX, isNight))) return Color.DKGRAY;
+                else return Color.LTGRAY;
             case PREF_COLOR_BACKGROUND_SUFFIX:
             default:
                 return ContextCompat.getColor(getDayNightContext(context, isNight), R.color.keyboard_background);

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -221,7 +221,8 @@ Nouveau dictionnaire:
     <string name="select_color_key_hint">Indice des touches</string>
     <string name="select_color_key_background">Arrière-plan des touches</string>
     <string name="select_color_functional_key_background">Arrière-plan des touches fonctionnelles</string>
-    <string name="select_color_space_bar_background">Arrière-plan de la barre d\'espace</string>
+    <string name="select_color_spacebar_background">Arrière-plan de la barre d\'espace</string>
+    <string name="select_color_spacebar_text">Texte de la barre d\'espace</string>
     <string name="select_color_accent">Couleur d\'accentuation</string>
     <string name="settings_screen_about">À propos</string>
     <string name="about_github_link" >Lien vers GitHub</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -220,6 +220,8 @@ Nouveau dictionnaire:
     <string name="select_color_key">Texte des touches</string>
     <string name="select_color_key_hint">Indice des touches</string>
     <string name="select_color_key_background">Arrière-plan des touches</string>
+    <string name="select_color_functional_key_background">Arrière-plan des touches fonctionnelles</string>
+    <string name="select_color_space_bar_background">Arrière-plan de la barre d\'espace</string>
     <string name="select_color_accent">Couleur d\'accentuation</string>
     <string name="settings_screen_about">À propos</string>
     <string name="about_github_link" >Lien vers GitHub</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -49,11 +49,13 @@
 
     <!-- Color resources for the old LXX_Light theme, now used for THEME_LIGHT. -->
     <color name="key_hint_letter_color_lxx_light">#B337474F</color>
+    <color name="spacebar_letter_color_lxx_light">#B337474F</color>
     <color name="key_text_color_lxx_light">#37474F</color>
 
     <!-- Color resources for the old LXX_Dark theme, now used for several dark themes. -->
     <color name="key_text_color_lxx_dark">#FFFFFF</color>
     <color name="key_hint_letter_color_lxx_dark">#80FFFFFF</color>
+    <color name="spacebar_letter_color_lxx_dark">#80FFFFFF</color>
 
     <!-- Color resources for the old LXX_Dark_Border theme, now for THEME_DARKER. -->
     <color name="keyboard_background_lxx_dark_border">#0d0d0d</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,7 +609,9 @@ New dictionary:
     <!-- Selection: functional key color. -->
     <string name="select_color_functional_key_background">Functional key background</string>
     <!-- Selection: space bar color. -->
-    <string name="select_color_space_bar_background">Space bar background</string>
+    <string name="select_color_spacebar_background">Space bar background</string>
+    <!-- Selection: space bar text color. -->
+    <string name="select_color_spacebar_text">Space bar text</string>
     <!-- Selection: accent color. -->
     <string name="select_color_accent">Accent</string>
     <!-- Settings screen title for about [CHAR LIMIT=33]-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,6 +606,10 @@ New dictionary:
     <string name="select_color_key_hint">Key hint text</string>
     <!-- Selection: key color. -->
     <string name="select_color_key_background">Key background</string>
+    <!-- Selection: functional key color. -->
+    <string name="select_color_functional_key_background">Functional key background</string>
+    <!-- Selection: space bar color. -->
+    <string name="select_color_space_bar_background">Space bar background</string>
     <!-- Selection: accent color. -->
     <string name="select_color_accent">Accent</string>
     <!-- Settings screen title for about [CHAR LIMIT=33]-->


### PR DESCRIPTION
As discussed (https://github.com/Helium314/openboard/pull/201#issuecomment-1773686304), users now have the option of changing more colors for a user-defined theme.
This applies to the background color of the **space bar** and **functional keys**.

**Automatic color selection is also retained.**

| Screenshot 1 | Screenshot 2 | Screenshot 3|
| :-------------: | :-------------: | :-------------: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/fb287ed9-85b0-4a5b-acbf-1c694469f174"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/d52d92bc-8581-4b5a-9284-537dce942f4c"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/ad3b00e1-b412-4f3c-839c-7582997d8cf2"> |