### PR TITLE
Add "Default" button to the color picker

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
@@ -130,7 +130,13 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
                     }
                 // The Default button appears only when a color has already been defined
                 if (csb.colorSwitch.isChecked) {
-                    builder.setNeutralButton(R.string.button_default, null)
+                    // Reset the color and the color picker to their initial state
+                    builder.setNeutralButton(R.string.button_default) { _, _ ->
+                        csb.colorSwitch.isChecked = false
+                        val resetColor = Settings.readUserColor(prefs, requireContext(), colorPrefs[index], isNight)
+                        picker.color = resetColor
+                        csb.colorSwitch.toggle()
+                    }
                 }
                 val dialog = builder.create()
                 dialog.show()
@@ -142,14 +148,6 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
                     dialog.window?.setLayout(wrapContent, wrapContent)
                 else
                     dialog.window?.setLayout(widthPortrait, wrapContent)
-                // Reset the color and the color picker to their initial state
-                dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
-                    csb.colorSwitch.isChecked = false
-                    val resetColor = Settings.readUserColor(prefs, requireContext(), colorPrefs[index], isNight)
-                    picker.color = resetColor
-                    csb.colorSwitch.toggle()
-                    dialog.dismiss()
-                }
             }
             csb.colorTextContainer.setOnClickListener(clickListener)
             csb.colorPreview.setOnClickListener(clickListener)

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/ColorsSettingsFragment.kt
@@ -128,6 +128,10 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
                         }
                         reloadKeyboard(hidden)
                     }
+                // The Default button appears only when a color has already been defined
+                if (csb.colorSwitch.isChecked) {
+                    builder.setNeutralButton(R.string.button_default, null)
+                }
                 val dialog = builder.create()
                 dialog.show()
                 // Reduce the size of the dialog in portrait mode
@@ -138,6 +142,14 @@ open class ColorsSettingsFragment : Fragment(R.layout.color_settings) {
                     dialog.window?.setLayout(wrapContent, wrapContent)
                 else
                     dialog.window?.setLayout(widthPortrait, wrapContent)
+                // Reset the color and the color picker to their initial state
+                dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+                    csb.colorSwitch.isChecked = false
+                    val resetColor = Settings.readUserColor(prefs, requireContext(), colorPrefs[index], isNight)
+                    picker.color = resetColor
+                    csb.colorSwitch.toggle()
+                    dialog.dismiss()
+                }
             }
             csb.colorTextContainer.setOnClickListener(clickListener)
             csb.colorPreview.setOnClickListener(clickListener)


### PR DESCRIPTION
A "Default" button is added to the dialog of color picker:
- it only appears if a color has already been selected;
- color and color picker are reset to their initial state.

| Initial Color | Color defined |
| :-----------: | :--------------: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/891cdcb9-eb11-4bf0-b3fd-52cc554247d7"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/1552b62b-5274-48e3-87e7-1bde32d8c70f"> |