### PR TITLE
Take hint label from moreKeys

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Key.java
@@ -1104,7 +1104,11 @@ public class Key implements Comparable<Key> {
             if ((mLabelFlags & LABEL_FLAGS_DISABLE_HINT_LABEL) != 0) {
                 mHintLabel = null;
             } else {
-                final String hintLabel = mMoreKeys == null ? null : mMoreKeys[0].mLabel;
+                String hintLabel = additionalMoreKeys == null ? null : additionalMoreKeys[0];
+                if (hintLabel != null && hintLabel.length() > 1 && hintLabel.startsWith("!"))
+                    hintLabel = null;
+                if (hintLabel != null && hintLabel.length() == 2 && hintLabel.startsWith("\\"))
+                    hintLabel = hintLabel.replace("\\", "");
                 mHintLabel = needsToUpcase
                         ? StringUtils.toTitleCaseOfKeyLabel(hintLabel, localeForUpcasing)
                         : hintLabel;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Key.java
@@ -1104,7 +1104,7 @@ public class Key implements Comparable<Key> {
             if ((mLabelFlags & LABEL_FLAGS_DISABLE_HINT_LABEL) != 0) {
                 mHintLabel = null;
             } else {
-                final String hintLabel = style.getString(keyAttr, R.styleable.Keyboard_Key_keyHintLabel);
+                final String hintLabel = mMoreKeys == null ? null : mMoreKeys[0].mLabel;
                 mHintLabel = needsToUpcase
                         ? StringUtils.toTitleCaseOfKeyLabel(hintLabel, localeForUpcasing)
                         : hintLabel;


### PR DESCRIPTION
With this change the hint label will be derived from the first key in `moreKeys`, which is the one that comes up on long press.
It would allow to simplify keyboard layouts by removing keyHintLabels.

In normal English QWERTY layout there are (almost) no changes, but this is different for many other languages.
E.g. French AZERTY (without number row) will have `à` instead of `1`, beause that's the first choice on long press. It may be perceived as awkward because there is no nice "1234567890" on top, but a mix of numbers and letters. But on the other hand it is very clear about what you get on long pressing the key.
@BlackyHawky & @RHJihan do you have any opinion on this (also Bengali layout has some changes).

Further, now the symbol keyboards have hint labels, which again looks a bit awkward because not all letters have moreKeys. But it's a _massive_ help in finding long press keys on the symbol keyboard.
The last thing is the long press hint for the period key. That one should be removed, it looks really weird.