### PR TITLE
Add summary to "show_hints_from_first_popup_key"

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -207,8 +207,10 @@ Nouveau dictionnaire:
     <string name="localized_number_row_summary">Privilégie les chiffres en language local à la place des chiffres latins</string>
     <string name="prefs_long_press_keyboard_to_change_lang">Changer le mode de saisie avec la barre d\'espace</string>
     <string name="prefs_long_press_keyboard_to_change_lang_summary">Un appui long sur la barre d\'espace fera apparaître le menu de sélection des claviers</string>
-    <string name="show_hints">Afficher les caractères alternatifs</string>
+    <string name="show_hints">Afficher les indices de touches</string>
     <string name="show_hints_summary">Affiche les caractères alternatifs lors d\'un appui long</string>
+    <string name="show_hints_from_first_popup_key">Afficher les indices à partir de la première sélection du popup</string>
+    <string name="show_hints_from_first_popup_key_summary">Les caractères alternatifs par défaut sont remplacés par ceux sélectionnés en premier lors d\'un appui long</string>
     <string name="show_popup_hints">Afficher les indices sur les touches fonctionnelles</string>
     <string name="show_popup_hints_summary">Affiche un signe ( <b>…</b> ) sur les touches où un appui long déclenche une fonctionnalité supplémentaire</string>
     <string name="prefs_keyboard_height_scale">Échelle de hauteur du clavier</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,6 +240,8 @@
     <string name="show_hints_summary">Show long-press hints</string>
     <!-- Title of the settings to show hint based on actual long-press key -->
     <string name="show_hints_from_first_popup_key">Take hint label from first popup key</string>
+    <!-- Summary of the settings to show hint based on actual long-press key -->
+    <string name="show_hints_from_first_popup_key_summary">The default key hints are replaced by those selected first on a long press</string>
     <!-- Title of the settings to show "..." as hints for more functionality on long-press -->
     <string name="show_popup_hints">Show functional hints</string>
     <!-- Description of the show_popup_hints setting -->

--- a/app/src/main/res/xml/prefs_screen_preferences.xml
+++ b/app/src/main/res/xml/prefs_screen_preferences.xml
@@ -20,6 +20,7 @@
         <SwitchPreferenceCompat
             android:key="pref_hint_label_from_first_more_key"
             android:title="@string/show_hints_from_first_popup_key"
+            android:summary="@string/show_hints_from_first_popup_key_summary"
             android:defaultValue="false"
             android:persistent="true" />
 


### PR DESCRIPTION
As discussed here https://github.com/Helium314/openboard/pull/267#issuecomment-1849040156, summary added to "show_hints_from_first_popup_key"

French translations have also been added.