### PR TITLE
Updated minimum SDK to 21 and removed some unnecessary SDK checks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.dslul.openboard.inputmethod.latin"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 19
         versionName '1.4.5'

--- a/app/src/main/java/org/dslul/openboard/inputmethod/compat/TextInfoCompatUtils.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/compat/TextInfoCompatUtils.kt
@@ -6,7 +6,6 @@
 
 package org.dslul.openboard.inputmethod.compat
 
-import android.os.Build
 import android.view.textservice.TextInfo
 import org.dslul.openboard.inputmethod.annotations.UsedForTesting
 
@@ -22,9 +21,7 @@ object TextInfoCompatUtils {
     @UsedForTesting
     fun newInstance(charSequence: CharSequence, start: Int, end: Int, cookie: Int,
                     sequenceNumber: Int): TextInfo {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            return TextInfo(charSequence, start, end, cookie, sequenceNumber)
-        return TextInfo(charSequence.subSequence(start, end).toString(), cookie, sequenceNumber)
+        return TextInfo(charSequence, start, end, cookie, sequenceNumber)
     }
 
     /**
@@ -39,9 +36,6 @@ object TextInfoCompatUtils {
     @JvmStatic
     @UsedForTesting
     fun getCharSequenceOrString(textInfo: TextInfo): CharSequence {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            return textInfo.charSequence
-        val defaultValue = textInfo.text
-        return CompatUtils.invoke(textInfo, defaultValue, TEXT_INFO_GET_CHAR_SEQUENCE) as CharSequence
+        return textInfo.charSequence
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/compat/ViewOutlineProviderCompatUtilsLXX.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/compat/ViewOutlineProviderCompatUtilsLXX.kt
@@ -8,13 +8,10 @@ package org.dslul.openboard.inputmethod.compat
 
 import android.graphics.Outline
 import android.inputmethodservice.InputMethodService
-import android.os.Build
 import android.view.View
 import android.view.ViewOutlineProvider
-import androidx.annotation.RequiresApi
 import org.dslul.openboard.inputmethod.compat.ViewOutlineProviderCompatUtils.InsetsUpdater
 
-@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal object ViewOutlineProviderCompatUtilsLXX {
     fun setInsetsOutlineProvider(view: View): InsetsUpdater {
         val provider = InsetsOutlineProvider(view)

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AboutFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AboutFragment.java
@@ -6,9 +6,6 @@
 
 package org.dslul.openboard.inputmethod.latin.settings;
 
-import android.graphics.Color;
-import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
@@ -16,7 +13,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.preference.Preference;
 
 import org.dslul.openboard.inputmethod.latin.BuildConfig;
@@ -31,16 +27,6 @@ public final class AboutFragment extends SubScreenFragment {
     public void onCreate(final Bundle icicle) {
         super.onCreate(icicle);
         addPreferencesFromResource(R.xml.prefs_screen_about);
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            // need to set icon tint because old android versions don't use the vector drawables
-            for (int i = 0; i < getPreferenceScreen().getPreferenceCount(); i++) {
-                final Preference p = getPreferenceScreen().getPreference(0);
-                final Drawable icon = p.getIcon();
-                if (icon != null)
-                    DrawableCompat.setTint(icon, Color.WHITE);
-            }
-        }
 
         setupHiddenFeatures();
         setupVersionPref();

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/PreferencesSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/PreferencesSettingsFragment.java
@@ -9,14 +9,10 @@ package org.dslul.openboard.inputmethod.latin.settings;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.graphics.Color;
-import android.graphics.drawable.Drawable;
 import android.media.AudioManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.inputmethod.InputMethodSubtype;
 
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.preference.Preference;
 
 import org.dslul.openboard.inputmethod.keyboard.KeyboardLayoutSet;
@@ -35,16 +31,6 @@ public final class PreferencesSettingsFragment extends SubScreenFragment {
     public void onCreate(final Bundle icicle) {
         super.onCreate(icicle);
         addPreferencesFromResource(R.xml.prefs_screen_preferences);
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            // need to set icon tint because old android versions don't use the vector drawables
-            for (int i = 0; i < getPreferenceScreen().getPreferenceCount(); i++) {
-                final Preference p = getPreferenceScreen().getPreference(0);
-                final Drawable icon = p.getIcon();
-                if (icon != null)
-                    DrawableCompat.setTint(icon, Color.WHITE);
-            }
-        }
 
         final Resources res = getResources();
         final Context context = getActivity();


### PR DESCRIPTION
This PR aims to update the minimum SDK to 21 and remove some unnecessary SDK checks.

I tested the app on API 19 using Android Studio's emulator, but the app and keyboard constantly crash. While I am not sure what the issue is exactly, I believe API 19 and 20 are far too outdated to support. Additionally, starting from August 2023, Google Play services dropped support for API less than 21.

There are more checks for API 21 in the code that could be removed but I wanted to avoid modifying a lot of files in a single PR.