### PR TITLE
Add icon to "Save log" setting

### DIFF
--- a/app/src/main/res/drawable/ic_settings_about_log.xml
+++ b/app/src/main/res/drawable/ic_settings_about_log.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:inset="@dimen/settings_screen_icon_inset"
+    android:drawable="@drawable/ic_settings_about_log_foreground"/>

--- a/app/src/main/res/drawable/ic_settings_about_log_foreground.xml
+++ b/app/src/main/res/drawable/ic_settings_about_log_foreground.xml
@@ -1,0 +1,13 @@
+<!--
+    icon available in Android Studio
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="32dp"
+    android:width="32dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path
+        android:fillColor="@color/foreground"
+        android:pathData="M20,8h-2.81c-0.45,-0.78 -1.07,-1.45 -1.82,-1.96L17,4.41 15.59,3l-2.17,2.17C12.96,5.06 12.49,5 12,5c-0.49,0 -0.96,0.06 -1.41,0.17L8.41,3 7,4.41l1.62,1.63C7.88,6.55 7.26,7.22 6.81,8L4,8v2h2.09c-0.05,0.33 -0.09,0.66 -0.09,1v1L4,12v2h2v1c0,0.34 0.04,0.67 0.09,1L4,16v2h2.81c1.04,1.79 2.97,3 5.19,3s4.15,-1.21 5.19,-3L20,18v-2h-2.09c0.05,-0.33 0.09,-0.66 0.09,-1v-1h2v-2h-2v-1c0,-0.34 -0.04,-0.67 -0.09,-1L20,10L20,8zM14,16h-4v-2h4v2zM14,12h-4v-2h4v2z"/>
+</vector>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -242,6 +242,7 @@ Nouveau dictionnaire:
     <string name="select_color_gesture">Saisie gestuelle</string>
     <string name="settings_screen_about">À propos</string>
     <string name="about_github_link" >Lien vers GitHub</string>
+    <string name="save_log">Sauvegarder le journal</string>
     <string name="license" >Licence Open-source</string>
     <string name="prefs_force_incognito_mode">Forcer le mode incognito</string>
     <string name="theme_style">Style</string>

--- a/app/src/main/res/xml/prefs_screen_about.xml
+++ b/app/src/main/res/xml/prefs_screen_about.xml
@@ -44,6 +44,7 @@
 
     <Preference
         android:title="@string/save_log"
-        android:key="log_reader" > <!-- todo (low priority): add icon -->
+        android:icon="@drawable/ic_settings_about_log"
+        android:key="log_reader" >
     </Preference>
 </PreferenceScreen>


### PR DESCRIPTION
Add icon to "Save log" setting and French translation added.

Screenshot:
<img width=200 src=https://github.com/Helium314/openboard/assets/139015663/cf9de088-a452-49e3-8893-b3db012ed84f>
