### PR TITLE
Update Gradle, Kotlin, NDK, and dependencies to their latest versions.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlinx-serialization'
 
 android {
     compileSdk 34
-    buildToolsVersion = '33.0.2'
+    buildToolsVersion = '34.0.0'
 
     defaultConfig {
         applicationId "org.dslul.openboard.inputmethod.latin"
@@ -47,7 +47,7 @@ android {
         abortOnError false
     }
 
-    ndkVersion '25.2.9519653'
+    ndkVersion '26.1.10909125'
 
     packagingOptions {
         jniLibs {
@@ -77,14 +77,14 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.preference:preference:1.2.1' // includes appcompat
-    implementation 'androidx.recyclerview:recyclerview:1.3.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1" // why not working with 1.6.0?
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.1"
     implementation 'com.github.martin-stone:hsv-alpha-color-picker-android:3.1.0'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.12.4'
-    testImplementation 'org.mockito:mockito-inline:3.12.4'
+    testImplementation 'org.mockito:mockito-core:5.7.0'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'androidx.test:runner:1.5.2'
     testImplementation 'androidx.test:core:1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.9.21'
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
 


### PR DESCRIPTION
This PR aims to update Gradle, Kotlin, NDK, and dependencies to their latest versions. There was a comment mentioning that "org.jetbrains.kotlinx:kotlinx-serialization-json" is not working on version 1.6.0, but I am not seeing any issues with version 1.6.1. 