### PR TITLE
Allow resizing emoji and clipboard views

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/compat/TabHostCompat.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/compat/TabHostCompat.java
@@ -12,6 +12,7 @@ import android.util.AttributeSet;
 import android.widget.TabHost;
 
 import org.dslul.openboard.inputmethod.latin.R;
+import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 
 /*
  * Custom version of {@link TabHost} that triggers its {@link TabHost.OnTabChangeListener} when
@@ -59,11 +60,11 @@ public class TabHostCompat extends TabHost implements TabHost.OnTabChangeListene
         mFireOnTabChangeListenerOnReselection = whether;
     }
 
-    // EmojiPalettesView onMeasure changes things here, we don't want that...
     @Override public void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         final Resources res = getContext().getResources();
-        final int width = res.getDisplayMetrics().widthPixels;
+        // fill full width, otherwise the layout is messed up
+        final int width = ResourceUtils.getDefaultKeyboardWidth(res);
         final int height = res.getDimensionPixelSize(R.dimen.config_suggestions_strip_height);
         setMeasuredDimension(width, height);
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/compat/TabHostCompat.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/compat/TabHostCompat.java
@@ -7,8 +7,11 @@
 package org.dslul.openboard.inputmethod.compat;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.util.AttributeSet;
 import android.widget.TabHost;
+
+import org.dslul.openboard.inputmethod.latin.R;
 
 /*
  * Custom version of {@link TabHost} that triggers its {@link TabHost.OnTabChangeListener} when
@@ -54,5 +57,14 @@ public class TabHostCompat extends TabHost implements TabHost.OnTabChangeListene
 
     public void setFireOnTabChangeListenerOnReselection(boolean whether) {
         mFireOnTabChangeListenerOnReselection = whether;
+    }
+
+    // EmojiPalettesView onMeasure changes things here, we don't want that...
+    @Override public void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        final Resources res = getContext().getResources();
+        final int width = res.getDisplayMetrics().widthPixels;
+        final int height = res.getDimensionPixelSize(R.dimen.config_suggestions_strip_height);
+        setMeasuredDimension(width, height);
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Keyboard.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/Keyboard.java
@@ -49,12 +49,12 @@ public class Keyboard {
     /** Total height of the keyboard, including the padding and keys */
     public final int mOccupiedHeight;
     /** Total width of the keyboard, including the padding and keys */
-    public final int mOccupiedWidth;
+    public int mOccupiedWidth;
 
     /** Base height of the keyboard, used to calculate rows' height */
     public final int mBaseHeight;
     /** Base width of the keyboard, used to calculate keys' width */
-    public final int mBaseWidth;
+    public int mBaseWidth;
 
     /** The padding above the keyboard */
     public final int mTopPadding;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -450,9 +450,16 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
 
         settings.writeOneHandedModeEnabled(enabled);
 
-        // Reload the entire keyboard set with the same parameters
+        // Reload the entire keyboard set with the same parameters, and switch to the previous layout
+        boolean wasEmoji = isShowingEmojiPalettes();
+        boolean wasClipboard = isShowingClipboardHistory();
         loadKeyboard(mLatinIME.getCurrentInputEditorInfo(), settings.getCurrent(),
                 mLatinIME.getCurrentAutoCapsState(), mLatinIME.getCurrentRecapitalizeState());
+        if (wasEmoji)
+            setEmojiKeyboard();
+        else if (wasClipboard) {
+            setClipboardKeyboard();
+        }
     }
 
     // Implements {@link KeyboardState.SwitchActions}.

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -278,8 +278,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private void setMainKeyboardFrame(
             @NonNull final SettingsValues settingsValues,
             @NonNull final KeyboardSwitchState toggleState) {
-        final int visibility =  isImeSuppressedByHardwareKeyboard(settingsValues, toggleState)
-                ? View.GONE : View.VISIBLE;
+        final int visibility = isImeSuppressedByHardwareKeyboard(settingsValues, toggleState) ? View.GONE : View.VISIBLE;
         mKeyboardView.setVisibility(visibility);
         // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
         // @see #getVisibleKeyboardView() and

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -47,6 +47,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private View mMainKeyboardFrame;
     private MainKeyboardView mKeyboardView;
     private EmojiPalettesView mEmojiPalettesView;
+    private View mEmojiTabStripView;
+    private View mSuggestionStripView;
     private ClipboardHistoryView mClipboardHistoryView;
     private LatinIME mLatinIME;
     private RichInputMethodManager mRichImm;
@@ -285,6 +287,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mMainKeyboardFrame.setVisibility(visibility);
         mEmojiPalettesView.setVisibility(View.GONE);
         mEmojiPalettesView.stopEmojiPalettes();
+        mEmojiTabStripView.setVisibility(View.GONE);
+        mSuggestionStripView.setVisibility(View.VISIBLE);
         mClipboardHistoryView.setVisibility(View.GONE);
         mClipboardHistoryView.stopClipboardHistory();
     }
@@ -296,11 +300,14 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
             Log.d(TAG, "setEmojiKeyboard");
         }
         final Keyboard keyboard = mKeyboardLayoutSet.getKeyboard(KeyboardId.ELEMENT_ALPHABET);
-        mMainKeyboardFrame.setVisibility(View.GONE);
+        mMainKeyboardFrame.setVisibility(View.VISIBLE);
         // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
         // @see #getVisibleKeyboardView() and
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
+        mSuggestionStripView.setVisibility(View.GONE);
+        mEmojiTabStripView.setVisibility(View.VISIBLE);
+        mClipboardHistoryView.setVisibility(View.GONE);
         mEmojiPalettesView.startEmojiPalettes(
                 mKeyboardTextsSet.getText(KeyboardTextsSet.SWITCH_TO_ALPHA_KEY_LABEL),
                 mKeyboardView.getKeyVisualAttribute(), keyboard.mIconsSet);
@@ -314,11 +321,14 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
             Log.d(TAG, "setClipboardKeyboard");
         }
         final Keyboard keyboard = mKeyboardLayoutSet.getKeyboard(KeyboardId.ELEMENT_ALPHABET);
-        mMainKeyboardFrame.setVisibility(View.GONE);
+        mMainKeyboardFrame.setVisibility(View.VISIBLE);
         // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
         // @see #getVisibleKeyboardView() and
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
+        mEmojiTabStripView.setVisibility(View.GONE);
+        mSuggestionStripView.setVisibility(View.VISIBLE);
+        mEmojiPalettesView.setVisibility(View.GONE);
         mClipboardHistoryView.startClipboardHistory(
                 mLatinIME.getClipboardHistoryManager(),
                 mKeyboardTextsSet.getText(KeyboardTextsSet.SWITCH_TO_ALPHA_KEY_LABEL),
@@ -433,6 +443,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (mKeyboardViewWrapper.getOneHandedModeEnabled() == enabled) {
             return;
         }
+        KeyboardLayoutSet.onKeyboardThemeChanged(); // clear caches
+        mEmojiPalettesView.clearCache();
         final Settings settings = Settings.getInstance();
         mKeyboardViewWrapper.setOneHandedModeEnabled(enabled);
         mKeyboardViewWrapper.setOneHandedGravity(settings.getCurrent().mOneHandedModeGravity);
@@ -503,7 +515,15 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         } else if (isShowingClipboardHistory()) {
             return mClipboardHistoryView;
         }
+        return mKeyboardView;
+    }
+
+    public View getWrapperView() {
         return mKeyboardViewWrapper;
+    }
+
+    public View getEmojiTabStrip() {
+        return mEmojiTabStripView;
     }
 
     public MainKeyboardView getMainKeyboardView() {
@@ -544,6 +564,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mEmojiPalettesView.setKeyboardActionListener(mLatinIME);
         mClipboardHistoryView.setHardwareAcceleratedDrawingEnabled(isHardwareAcceleratedDrawingEnabled);
         mClipboardHistoryView.setKeyboardActionListener(mLatinIME);
+        mEmojiTabStripView = mCurrentInputView.findViewById(R.id.emoji_tab_strip);
+        mSuggestionStripView = mCurrentInputView.findViewById(R.id.suggestion_strip_view);
+        mEmojiPalettesView.initialStart();
 
         return mCurrentInputView;
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -443,8 +443,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (mKeyboardViewWrapper.getOneHandedModeEnabled() == enabled) {
             return;
         }
-        KeyboardLayoutSet.onKeyboardThemeChanged(); // clear caches
-        mEmojiPalettesView.clearCache();
+        mEmojiPalettesView.clearKeyboardCache();
         final Settings settings = Settings.getInstance();
         mKeyboardViewWrapper.setOneHandedModeEnabled(enabled);
         mKeyboardViewWrapper.setOneHandedGravity(settings.getCurrent().mOneHandedModeGravity);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
@@ -213,8 +213,7 @@ public class KeyboardView extends View {
         }
 
         mKeyboard = keyboard;
-        final SettingsValues sv = Settings.getInstance().getCurrent();
-        mKeyScaleForText = (float) Math.sqrt(1 / sv.mKeyboardHeightScale);
+        mKeyScaleForText = (float) Math.sqrt(1 / Settings.getInstance().getCurrent().mKeyboardHeightScale);
         final int scaledKeyHeight = (int) ((keyboard.mMostCommonKeyHeight - keyboard.mVerticalGap) * mKeyScaleForText);
         mKeyDrawParams.updateParams(scaledKeyHeight, mKeyVisualAttributes);
         mKeyDrawParams.updateParams(scaledKeyHeight, keyboard.mKeyVisualAttributes);
@@ -358,6 +357,7 @@ public class KeyboardView extends View {
         canvas.translate(keyDrawX, keyDrawY);
 
         final KeyVisualAttributes attr = key.getVisualAttributes();
+        // don't use the raw key height, linear font scaling with height is too extreme
         final KeyDrawParams params = mKeyDrawParams.mayCloneAndUpdateParams((int) (key.getHeight() * mKeyScaleForText), attr);
         params.mAnimAlpha = Constants.Color.ALPHA_OPAQUE;
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardView.java
@@ -214,11 +214,7 @@ public class KeyboardView extends View {
 
         mKeyboard = keyboard;
         final SettingsValues sv = Settings.getInstance().getCurrent();
-        // scale should not depend on mOneHandedModeScale for emoji and clipboard, because those views are not affected by one-handed mode (yet)
-        if (keyboard.mId.isEmojiKeyboard() || keyboard.mId.mElementId == KeyboardId.ELEMENT_CLIPBOARD)
-            mKeyScaleForText = (float) Math.sqrt(1 / sv.mKeyboardHeightScale);
-        else
-            mKeyScaleForText = (float) Math.sqrt(sv.mOneHandedModeScale / sv.mKeyboardHeightScale);
+        mKeyScaleForText = (float) Math.sqrt(1 / sv.mKeyboardHeightScale);
         final int scaledKeyHeight = (int) ((keyboard.mMostCommonKeyHeight - keyboard.mVerticalGap) * mKeyScaleForText);
         mKeyDrawParams.updateParams(scaledKeyHeight, mKeyVisualAttributes);
         mKeyDrawParams.updateParams(scaledKeyHeight, keyboard.mKeyVisualAttributes);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
@@ -57,7 +57,6 @@ class ClipboardHistoryView @JvmOverloads constructor(
     }
 
     // todo: issues
-    //  abc button is full width, but should be scaled in one-handed mode (minor)
     //  suggestion strip on top is a bit out of place, replace it? or force show toolbar?
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
@@ -59,7 +59,6 @@ class ClipboardHistoryView @JvmOverloads constructor(
     // todo: issues
     //  abc button is full width, but should be scaled in one-handed mode (minor)
     //  suggestion strip on top is a bit out of place, replace it? or force show toolbar?
-    // todo: maybe can be removed?
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         val res = context.resources

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
@@ -156,7 +156,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
         }
         clipboardRecyclerView.apply {
             adapter = clipboardAdapter
-            layoutParams.width = ResourceUtils.getKeyboardWidth(context.resources, Settings.getInstance().current) // todo: maybe on measure, because of rotate?
+            layoutParams.width = ResourceUtils.getKeyboardWidth(context.resources, Settings.getInstance().current)
         }
         Settings.getInstance().current.mColors.setBackground(this, ColorType.CLIPBOARD_BACKGROUND)
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
@@ -56,8 +56,9 @@ class ClipboardHistoryView @JvmOverloads constructor(
         keyboardViewAttr.recycle()
     }
 
-    // todo: issues
-    //  suggestion strip on top is a bit out of place, replace it? or force show toolbar?
+    // todo: add another strip to clipboard, with select all, arrow keys, select, copy, clear buttons
+    //  at the bottom, remove the clear button and add the keys like in the emoji view (abc, space, delete)
+    //  also allow swipe to remove a word from clipboard history (except current clip and pinned clips)
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         val res = context.resources

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardHistoryView.kt
@@ -56,14 +56,17 @@ class ClipboardHistoryView @JvmOverloads constructor(
         keyboardViewAttr.recycle()
     }
 
+    // todo: issues
+    //  abc button is full width, but should be scaled in one-handed mode (minor)
+    //  suggestion strip on top is a bit out of place, replace it? or force show toolbar?
+    // todo: maybe can be removed?
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         val res = context.resources
         // The main keyboard expands to the entire this {@link KeyboardView}.
-        val width = (ResourceUtils.getDefaultKeyboardWidth(res) + paddingLeft + paddingRight)
-        val height = (ResourceUtils.getKeyboardHeight(res, Settings.getInstance().current)
-                + res.getDimensionPixelSize(R.dimen.config_suggestions_strip_height)
-                + paddingTop + paddingBottom)
+        val width = ResourceUtils.getKeyboardWidth(res, Settings.getInstance().current) + paddingLeft + paddingRight
+        val height = ResourceUtils.getKeyboardHeight(res, Settings.getInstance().current) + paddingTop + paddingBottom
+        findViewById<FrameLayout>(R.id.clipboard_action_bar)?.layoutParams?.width = width
         setMeasuredDimension(width, height)
     }
 
@@ -154,6 +157,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
         }
         clipboardRecyclerView.apply {
             adapter = clipboardAdapter
+            layoutParams.width = ResourceUtils.getKeyboardWidth(context.resources, Settings.getInstance().current) // todo: maybe on measure, because of rotate?
         }
         Settings.getInstance().current.mColors.setBackground(this, ColorType.CLIPBOARD_BACKGROUND)
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardLayoutParams.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardLayoutParams.kt
@@ -44,7 +44,8 @@ class ClipboardLayoutParams(res: Resources) {
         topPadding = res.getFraction(R.fraction.config_keyboard_top_padding_holo,
                 defaultKeyboardHeight, defaultKeyboardHeight).toInt()
 
-        actionBarHeight = (defaultKeyboardHeight - bottomPadding - topPadding) / DEFAULT_KEYBOARD_ROWS - keyVerticalGap / 2
+        val numRows = if (Settings.getInstance().current.mShowsNumberRow) 1 else 0
+        actionBarHeight = (defaultKeyboardHeight - bottomPadding - topPadding) / (DEFAULT_KEYBOARD_ROWS + numRows) - keyVerticalGap / 2
         listHeight = defaultKeyboardHeight - actionBarHeight - bottomPadding
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardLayoutParams.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardLayoutParams.kt
@@ -44,8 +44,8 @@ class ClipboardLayoutParams(res: Resources) {
         topPadding = res.getFraction(R.fraction.config_keyboard_top_padding_holo,
                 defaultKeyboardHeight, defaultKeyboardHeight).toInt()
 
-        val numRows = if (Settings.getInstance().current.mShowsNumberRow) 1 else 0
-        actionBarHeight = (defaultKeyboardHeight - bottomPadding - topPadding) / (DEFAULT_KEYBOARD_ROWS + numRows) - keyVerticalGap / 2
+        val rowCount = DEFAULT_KEYBOARD_ROWS + if (Settings.getInstance().current.mShowsNumberRow) 1 else 0
+        actionBarHeight = (defaultKeyboardHeight - bottomPadding - topPadding) / rowCount - keyVerticalGap / 2
         listHeight = defaultKeyboardHeight - actionBarHeight - bottomPadding
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardLayoutParams.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/clipboard/ClipboardLayoutParams.kt
@@ -26,8 +26,7 @@ class ClipboardLayoutParams(res: Resources) {
 
     init {
         val defaultKeyboardHeight = ResourceUtils.getKeyboardHeight(res, Settings.getInstance().current)
-        val suggestionStripHeight = res.getDimensionPixelSize(R.dimen.config_suggestions_strip_height)
-        val defaultKeyboardWidth = ResourceUtils.getDefaultKeyboardWidth(res)
+        val defaultKeyboardWidth = ResourceUtils.getKeyboardWidth(res, Settings.getInstance().current)
 
         if (Settings.getInstance().current.mNarrowKeyGaps) {
             keyVerticalGap = res.getFraction(R.fraction.config_key_vertical_gap_holo_narrow,
@@ -46,7 +45,7 @@ class ClipboardLayoutParams(res: Resources) {
                 defaultKeyboardHeight, defaultKeyboardHeight).toInt()
 
         actionBarHeight = (defaultKeyboardHeight - bottomPadding - topPadding) / DEFAULT_KEYBOARD_ROWS - keyVerticalGap / 2
-        listHeight = defaultKeyboardHeight + suggestionStripHeight - actionBarHeight - bottomPadding
+        listHeight = defaultKeyboardHeight - actionBarHeight - bottomPadding
     }
 
     fun setListProperties(recycler: RecyclerView) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
@@ -59,12 +59,10 @@ final class DynamicGridKeyboard extends Keyboard {
         final Key key1 = getTemplateKey(TEMPLATE_KEY_CODE_1);
         final int horizontalGap = Math.abs(key1.getX() - key0.getX()) - key0.getWidth();
         final float widthScale = determineWidthScale(key0.getWidth(), horizontalGap);
-        // todo: works well, but now bottom padding affects emoji size... damn
         mHorizontalGap = (int) (horizontalGap * widthScale);
         mHorizontalStep = (int) ((key0.getWidth() + horizontalGap) * widthScale);
         mVerticalStep = (int) ((key0.getHeight() + mVerticalGap) / Math.sqrt(Settings.getInstance().getCurrent().mKeyboardHeightScale));
         mColumnsNum = mBaseWidth / mHorizontalStep;
-        Log.i("test", "creating keyboard, step "+mHorizontalStep+", "+mVerticalStep+", "+mColumnsNum+" columns, bw "+mBaseWidth+", scale "+widthScale);
         mMaxKeyCount = maxKeyCount;
         mIsRecents = categoryId == EmojiCategory.ID_RECENTS;
         mPrefs = prefs;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
@@ -49,17 +49,33 @@ final class DynamicGridKeyboard extends Keyboard {
     private List<Key> mCachedGridKeys;
 
     public DynamicGridKeyboard(final SharedPreferences prefs, final Keyboard templateKeyboard,
-            final int maxKeyCount, final int categoryId) {
+            final int maxKeyCount, final int categoryId, final int width) {
         super(templateKeyboard);
+        // todo: would be better to keep them final and not require width, but how to properly set width of the template keyboard?
+        final int paddingWidth = mOccupiedWidth - mBaseWidth;
+        mBaseWidth = width - paddingWidth;
+        mOccupiedWidth = width;
         final Key key0 = getTemplateKey(TEMPLATE_KEY_CODE_0);
         final Key key1 = getTemplateKey(TEMPLATE_KEY_CODE_1);
-        mHorizontalGap = Math.abs(key1.getX() - key0.getX()) - key0.getWidth();
-        mHorizontalStep = key0.getWidth() + mHorizontalGap;
-        mVerticalStep = key0.getHeight() + mVerticalGap;
+        final int horizontalGap = Math.abs(key1.getX() - key0.getX()) - key0.getWidth();
+        final float widthScale = determineWidthScale(key0.getWidth(), horizontalGap);
+        // todo: works well, but now bottom padding affects emoji size... damn
+        mHorizontalGap = (int) (horizontalGap * widthScale);
+        mHorizontalStep = (int) ((key0.getWidth() + horizontalGap) * widthScale);
+        mVerticalStep = (int) ((key0.getHeight() + mVerticalGap) / Math.sqrt(Settings.getInstance().getCurrent().mKeyboardHeightScale));
         mColumnsNum = mBaseWidth / mHorizontalStep;
+        Log.i("test", "creating keyboard, step "+mHorizontalStep+", "+mVerticalStep+", "+mColumnsNum+" columns, bw "+mBaseWidth+", scale "+widthScale);
         mMaxKeyCount = maxKeyCount;
         mIsRecents = categoryId == EmojiCategory.ID_RECENTS;
         mPrefs = prefs;
+    }
+
+    // determine a width scale so the keyboard is completely filled
+    private float determineWidthScale(final float keyWidth, final float horizontalGap) {
+        final float horizontalStep = horizontalGap + keyWidth;
+        final float columnsNumRaw = mBaseWidth / horizontalStep;
+        final float columnsNum = Math.round(columnsNumRaw);
+        return columnsNumRaw / columnsNum;
     }
 
     private Key getTemplateKey(final int code) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
@@ -52,13 +52,14 @@ final class DynamicGridKeyboard extends Keyboard {
             final int maxKeyCount, final int categoryId, final int width) {
         super(templateKeyboard);
         // todo: would be better to keep them final and not require width, but how to properly set width of the template keyboard?
+        //  an alternative would be to always create the templateKeyboard with full width
         final int paddingWidth = mOccupiedWidth - mBaseWidth;
         mBaseWidth = width - paddingWidth;
         mOccupiedWidth = width;
         final Key key0 = getTemplateKey(TEMPLATE_KEY_CODE_0);
         final Key key1 = getTemplateKey(TEMPLATE_KEY_CODE_1);
         final int horizontalGap = Math.abs(key1.getX() - key0.getX()) - key0.getWidth();
-        final float widthScale = determineWidthScale(key0.getWidth(), horizontalGap);
+        final float widthScale = determineWidthScale(key0.getWidth() + horizontalGap);
         mHorizontalGap = (int) (horizontalGap * widthScale);
         mHorizontalStep = (int) ((key0.getWidth() + horizontalGap) * widthScale);
         mVerticalStep = (int) ((key0.getHeight() + mVerticalGap) / Math.sqrt(Settings.getInstance().getCurrent().mKeyboardHeightScale));
@@ -68,9 +69,8 @@ final class DynamicGridKeyboard extends Keyboard {
         mPrefs = prefs;
     }
 
-    // determine a width scale so the keyboard is completely filled
-    private float determineWidthScale(final float keyWidth, final float horizontalGap) {
-        final float horizontalStep = horizontalGap + keyWidth;
+    // determine a width scale so emojis evenly fill the entire width
+    private float determineWidthScale(final float horizontalStep) {
         final float columnsNumRaw = mBaseWidth / horizontalStep;
         final float columnsNum = Math.round(columnsNumRaw);
         return columnsNumRaw / columnsNum;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiCategory.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiCategory.java
@@ -167,7 +167,7 @@ final class EmojiCategory {
         }
     }
 
-    public void clear() {
+    public void clearKeyboardCache() {
         mCategoryKeyboardMap.clear();
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiCategory.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiCategory.java
@@ -20,6 +20,7 @@ import org.dslul.openboard.inputmethod.keyboard.KeyboardId;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardLayoutSet;
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.settings.Settings;
+import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -118,8 +119,7 @@ final class EmojiCategory {
     private final HashMap<String, Integer> mCategoryNameToIdMap = new HashMap<>();
     private final int[] mCategoryTabIconId = new int[sCategoryName.length];
     private final ArrayList<CategoryProperties> mShownCategories = new ArrayList<>();
-    private final ConcurrentHashMap<Long, DynamicGridKeyboard> mCategoryKeyboardMap =
-            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, DynamicGridKeyboard> mCategoryKeyboardMap = new ConcurrentHashMap<>();
 
     private int mCurrentCategoryId = EmojiCategory.ID_UNSPECIFIED;
     private int mCurrentCategoryPageId = 0;
@@ -132,8 +132,7 @@ final class EmojiCategory {
         mLayoutSet = layoutSet;
         for (int i = 0; i < sCategoryName.length; ++i) {
             mCategoryNameToIdMap.put(sCategoryName[i], i);
-            mCategoryTabIconId[i] = emojiPaletteViewAttr.getResourceId(
-                    sCategoryTabIconAttr[i], 0);
+            mCategoryTabIconId[i] = emojiPaletteViewAttr.getResourceId(sCategoryTabIconAttr[i], 0);
         }
 
         int defaultCategoryId = EmojiCategory.ID_SMILEYS_EMOTION;
@@ -166,6 +165,10 @@ final class EmojiCategory {
         if (mCurrentCategoryPageId >= computeCategoryPageCount(mCurrentCategoryId)) {
             mCurrentCategoryPageId = 0;
         }
+    }
+
+    public void clear() {
+        mCategoryKeyboardMap.clear();
     }
 
     private void addShownCategoryId(final int categoryId) {
@@ -294,10 +297,11 @@ final class EmojiCategory {
                 return mCategoryKeyboardMap.get(categoryKeyboardMapKey);
             }
 
+            final int width = ResourceUtils.getKeyboardWidth(mRes, Settings.getInstance().getCurrent());
             if (categoryId == EmojiCategory.ID_RECENTS) {
                 final DynamicGridKeyboard kbd = new DynamicGridKeyboard(mPrefs,
                         mLayoutSet.getKeyboard(KeyboardId.ELEMENT_EMOJI_RECENTS),
-                        mMaxRecentsKeyCount, categoryId);
+                        mMaxRecentsKeyCount, categoryId, width);
                 mCategoryKeyboardMap.put(categoryKeyboardMapKey, kbd);
                 return kbd;
             }
@@ -309,15 +313,14 @@ final class EmojiCategory {
             for (int pageId = 0; pageId < sortedKeysPages.length; ++pageId) {
                 final DynamicGridKeyboard tempKeyboard = new DynamicGridKeyboard(mPrefs,
                         mLayoutSet.getKeyboard(KeyboardId.ELEMENT_EMOJI_RECENTS),
-                        keyCountPerPage, categoryId);
+                        keyCountPerPage, categoryId, width);
                 for (final Key emojiKey : sortedKeysPages[pageId]) {
                     if (emojiKey == null) {
                         break;
                     }
                     tempKeyboard.addKeyLast(emojiKey);
                 }
-                mCategoryKeyboardMap.put(
-                        getCategoryKeyboardMapKey(categoryId, pageId), tempKeyboard);
+                mCategoryKeyboardMap.put(getCategoryKeyboardMapKey(categoryId, pageId), tempKeyboard);
             }
             return mCategoryKeyboardMap.get(categoryKeyboardMapKey);
         }
@@ -326,7 +329,7 @@ final class EmojiCategory {
     private int computeMaxKeyCountPerPage() {
         final DynamicGridKeyboard tempKeyboard = new DynamicGridKeyboard(mPrefs,
                 mLayoutSet.getKeyboard(KeyboardId.ELEMENT_EMOJI_RECENTS),
-                0, 0);
+                0, 0, ResourceUtils.getKeyboardWidth(mRes, Settings.getInstance().getCurrent()));
         return MAX_LINE_COUNT_PER_PAGE * tempKeyboard.getColumnsCount();
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiCategory.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiCategory.java
@@ -297,11 +297,11 @@ final class EmojiCategory {
                 return mCategoryKeyboardMap.get(categoryKeyboardMapKey);
             }
 
-            final int width = ResourceUtils.getKeyboardWidth(mRes, Settings.getInstance().getCurrent());
+            final int currentWidth = ResourceUtils.getKeyboardWidth(mRes, Settings.getInstance().getCurrent());
             if (categoryId == EmojiCategory.ID_RECENTS) {
                 final DynamicGridKeyboard kbd = new DynamicGridKeyboard(mPrefs,
                         mLayoutSet.getKeyboard(KeyboardId.ELEMENT_EMOJI_RECENTS),
-                        mMaxRecentsKeyCount, categoryId, width);
+                        mMaxRecentsKeyCount, categoryId, currentWidth);
                 mCategoryKeyboardMap.put(categoryKeyboardMapKey, kbd);
                 return kbd;
             }
@@ -313,7 +313,7 @@ final class EmojiCategory {
             for (int pageId = 0; pageId < sortedKeysPages.length; ++pageId) {
                 final DynamicGridKeyboard tempKeyboard = new DynamicGridKeyboard(mPrefs,
                         mLayoutSet.getKeyboard(KeyboardId.ELEMENT_EMOJI_RECENTS),
-                        keyCountPerPage, categoryId, width);
+                        keyCountPerPage, categoryId, currentWidth);
                 for (final Key emojiKey : sortedKeysPages[pageId]) {
                     if (emojiKey == null) {
                         break;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiLayoutParams.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiLayoutParams.java
@@ -32,7 +32,7 @@ final class EmojiLayoutParams {
     public EmojiLayoutParams(final Resources res) {
         final SettingsValues settingsValues = Settings.getInstance().getCurrent();
         final int defaultKeyboardHeight = ResourceUtils.getKeyboardHeight(res, settingsValues);
-        final int defaultKeyboardWidth = ResourceUtils.getDefaultKeyboardWidth(res);
+        final int defaultKeyboardWidth = ResourceUtils.getKeyboardWidth(res, settingsValues);
         if (settingsValues.mNarrowKeyGaps) {
             mKeyVerticalGap = (int) res.getFraction(R.fraction.config_key_vertical_gap_holo_narrow,
                     defaultKeyboardHeight, defaultKeyboardHeight);
@@ -77,6 +77,7 @@ final class EmojiLayoutParams {
     public void setActionBarProperties(final LinearLayout ll) {
         final LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams) ll.getLayoutParams();
         lp.height = getActionBarHeight();
+        lp.width = ResourceUtils.getKeyboardWidth(ll.getResources(), Settings.getInstance().getCurrent());
         ll.setLayoutParams(lp);
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPageKeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPageKeyboardView.java
@@ -105,6 +105,7 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
         mMoreKeysKeyboardContainer = inflater.inflate(moreKeysKeyboardLayoutId, null);
     }
 
+    // todo: maybe can be removed?
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         final Keyboard keyboard = getKeyboard();

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPageKeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPageKeyboardView.java
@@ -105,14 +105,12 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
         mMoreKeysKeyboardContainer = inflater.inflate(moreKeysKeyboardLayoutId, null);
     }
 
-    // todo: maybe can be removed?
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         final Keyboard keyboard = getKeyboard();
         if (keyboard instanceof DynamicGridKeyboard) {
             final int width = keyboard.mOccupiedWidth + getPaddingLeft() + getPaddingRight();
-            final int occupiedHeight =
-                    ((DynamicGridKeyboard) keyboard).getDynamicOccupiedHeight();
+            final int occupiedHeight = ((DynamicGridKeyboard) keyboard).getDynamicOccupiedHeight();
             final int height = occupiedHeight + getPaddingTop() + getPaddingBottom();
             setMeasuredDimension(width, height);
             return;
@@ -186,8 +184,7 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
         }
 
         final View container = mMoreKeysKeyboardContainer;
-        final MoreKeysKeyboardView moreKeysKeyboardView =
-                container.findViewById(R.id.more_keys_keyboard_view);
+        final MoreKeysKeyboardView moreKeysKeyboardView = container.findViewById(R.id.more_keys_keyboard_view);
         moreKeysKeyboardView.setKeyboard(moreKeysKeyboard);
         container.measure(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 
@@ -199,8 +196,7 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
                 ? CoordinateUtils.x(lastCoords)
                 : key.getX() + key.getWidth() / 2;
         final int pointY = key.getY();
-        moreKeysKeyboardView.showMoreKeysPanel(this, this,
-                pointX, pointY, mListener);
+        moreKeysKeyboardView.showMoreKeysPanel(this, this, pointX, pointY, mListener);
         return moreKeysKeyboardView;
     }
 
@@ -254,10 +250,8 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
      */
     @Override
     public boolean onHoverEvent(final MotionEvent event) {
-        final KeyboardAccessibilityDelegate<EmojiPageKeyboardView> accessibilityDelegate =
-                mAccessibilityDelegate;
-        if (accessibilityDelegate != null
-                && AccessibilityUtils.Companion.getInstance().isTouchExplorationEnabled()) {
+        final KeyboardAccessibilityDelegate<EmojiPageKeyboardView> accessibilityDelegate = mAccessibilityDelegate;
+        if (accessibilityDelegate != null && AccessibilityUtils.Companion.getInstance().isTouchExplorationEnabled()) {
             return accessibilityDelegate.onHoverEvent(event);
         }
         return super.onHoverEvent(event);
@@ -388,12 +382,7 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
         } else if (key == currentKey && pendingKeyDown != null) {
             pendingKeyDown.run();
             // Trigger key-release event a little later so that a user can see visual feedback.
-            mHandler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    callListenerOnReleaseKey(key, true /* withRegistering */);
-                }
-            }, KEY_RELEASE_DELAY_TIME);
+            mHandler.postDelayed(() -> callListenerOnReleaseKey(key, true), KEY_RELEASE_DELAY_TIME);
         } else if (key != null) {
             callListenerOnReleaseKey(key, true /* withRegistering */);
         }
@@ -403,7 +392,7 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
     }
 
     public boolean onCancel(final MotionEvent e) {
-        releaseCurrentKey(false /* withKeyRegistering */);
+        releaseCurrentKey(false);
         dismissMoreKeysPanel();
         cancelLongPress();
         return true;
@@ -418,7 +407,7 @@ public final class EmojiPageKeyboardView extends KeyboardView implements
         // Touched key has changed, release previous key's callbacks and
         // re-register them for the new key.
         if (key != mCurrentKey && !isShowingMoreKeysPanel) {
-            releaseCurrentKey(false /* withKeyRegistering */);
+            releaseCurrentKey(false);
             mCurrentKey = key;
             if (key == null) {
                 return false;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -134,9 +134,6 @@ public final class EmojiPalettesView extends LinearLayout
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         final Resources res = getContext().getResources();
         // The main keyboard expands to the entire this {@link KeyboardView}.
-        // todo: currently looks a bit broken, because
-        //  when typing an emoji (or doing anything that affects suggestion strip), suggestion strip is added on top
-        //   this is annoying... try some frame layout where the suggestion strip is just behind the emoji tab?
         final int width = ResourceUtils.getKeyboardWidth(res, Settings.getInstance().getCurrent())
                 + getPaddingLeft() + getPaddingRight();
         final int height = ResourceUtils.getKeyboardHeight(res, Settings.getInstance().getCurrent())

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -479,7 +479,7 @@ public final class EmojiPalettesView extends LinearLayout
         }
     }
 
-    public void clearCache() {
-        mEmojiCategory.clear();
+    public void clearKeyboardCache() {
+        mEmojiCategory.clearKeyboardCache();
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -30,6 +30,7 @@ import org.dslul.openboard.inputmethod.compat.TabHostCompat;
 import org.dslul.openboard.inputmethod.keyboard.Key;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardActionListener;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardLayoutSet;
+import org.dslul.openboard.inputmethod.keyboard.KeyboardSwitcher;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardView;
 import org.dslul.openboard.inputmethod.keyboard.internal.KeyDrawParams;
 import org.dslul.openboard.inputmethod.keyboard.internal.KeyVisualAttributes;
@@ -108,7 +109,7 @@ public final class EmojiPalettesView extends LinearLayout
         final Resources res = context.getResources();
         mEmojiLayoutParams = new EmojiLayoutParams(res);
         builder.setSubtype(RichInputMethodSubtype.getEmojiSubtype());
-        builder.setKeyboardGeometry(ResourceUtils.getDefaultKeyboardWidth(res),
+        builder.setKeyboardGeometry(ResourceUtils.getKeyboardWidth(res, Settings.getInstance().getCurrent()),
                 mEmojiLayoutParams.mEmojiKeyboardHeight);
         final KeyboardLayoutSet layoutSet = builder.build();
         final TypedArray emojiPalettesViewAttr = context.obtainStyledAttributes(attrs,
@@ -133,10 +134,12 @@ public final class EmojiPalettesView extends LinearLayout
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         final Resources res = getContext().getResources();
         // The main keyboard expands to the entire this {@link KeyboardView}.
-        final int width = ResourceUtils.getDefaultKeyboardWidth(res)
+        // todo: currently looks a bit broken, because
+        //  when typing an emoji (or doing anything that affects suggestion strip), suggestion strip is added on top
+        //   this is annoying... try some frame layout where the suggestion strip is just behind the emoji tab?
+        final int width = ResourceUtils.getKeyboardWidth(res, Settings.getInstance().getCurrent())
                 + getPaddingLeft() + getPaddingRight();
         final int height = ResourceUtils.getKeyboardHeight(res, Settings.getInstance().getCurrent())
-                + res.getDimensionPixelSize(R.dimen.config_suggestions_strip_height)
                 + getPaddingTop() + getPaddingBottom();
         setMeasuredDimension(width, height);
     }
@@ -155,14 +158,11 @@ public final class EmojiPalettesView extends LinearLayout
         host.addTab(tspec);
     }
 
-    @Override
-    protected void onFinishInflate() {
-        super.onFinishInflate();
+    public void initialStart() { // needs to be delayed for access to EmojiTabStrip
 
-        mTabHost = findViewById(R.id.emoji_category_tabhost);
+        mTabHost = KeyboardSwitcher.getInstance().getEmojiTabStrip().findViewById(R.id.emoji_category_tabhost);
         mTabHost.setup();
-        for (final EmojiCategory.CategoryProperties properties
-                : mEmojiCategory.getShownCategories()) {
+        for (final EmojiCategory.CategoryProperties properties : mEmojiCategory.getShownCategories()) {
             addTab(mTabHost, properties.mCategoryId);
         }
         mTabHost.setOnTabChangedListener(this);
@@ -225,9 +225,6 @@ public final class EmojiPalettesView extends LinearLayout
                 true /* force */);
         // Enable reselection after the first setCurrentCategoryAndPageId() init call
         mTabHost.setFireOnTabChangeListenerOnReselection(true);
-
-        final LinearLayout actionBar = findViewById(R.id.emoji_action_bar);
-        mEmojiLayoutParams.setActionBarProperties(actionBar);
 
         // deleteKey depends only on OnTouchListener.
         mDeleteKey = findViewById(R.id.emoji_keyboard_delete);
@@ -378,6 +375,7 @@ public final class EmojiPalettesView extends LinearLayout
         if (deleteIconResId != 0) {
             mDeleteKey.setImageResource(deleteIconResId);
         }
+        mEmojiLayoutParams.setActionBarProperties(findViewById(R.id.emoji_action_bar));
         final KeyDrawParams params = new KeyDrawParams();
         params.updateParams(mEmojiLayoutParams.getActionBarHeight(), keyVisualAttr);
         setupAlphabetKey(mAlphabetKeyLeft, switchToAlphaLabel, params);
@@ -479,5 +477,9 @@ public final class EmojiPalettesView extends LinearLayout
         private void onTouchCanceled(final View v) {
             v.setPressed(false);
         }
+    }
+
+    public void clearCache() {
+        mEmojiCategory.clear();
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -155,8 +155,7 @@ public final class EmojiPalettesView extends LinearLayout
         host.addTab(tspec);
     }
 
-    public void initialStart() { // needs to be delayed for access to EmojiTabStrip
-
+    public void initialStart() { // needs to be delayed for access to EmojiTabStrip, which is not a child of this view
         mTabHost = KeyboardSwitcher.getInstance().getEmojiTabStrip().findViewById(R.id.emoji_category_tabhost);
         mTabHost.setup();
         for (final EmojiCategory.CategoryProperties properties : mEmojiCategory.getShownCategories()) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/keyboard_parser/EmojiParser.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/keyboard_parser/EmojiParser.kt
@@ -64,9 +64,14 @@ class EmojiParser(private val params: KeyboardParams, private val context: Conte
         var currentX = params.mLeftPadding.toFloat()
         val currentY = params.mTopPadding.toFloat() // no need to ever change, assignment to rows into rows is done in DynamicGridKeyboard
 
+        // determine key width for default settings (no number row, no one-handed mode, 100% height and bottom padding scale)
+        // this is a bit long, but ensures that emoji size stays the same, independent of these settings
         val defaultKeyWidth = (ResourceUtils.getDefaultKeyboardWidth(context.resources) - params.mLeftPadding - params.mRightPadding) * params.mDefaultRelativeKeyWidth
         val keyWidth = defaultKeyWidth * sqrt(Settings.getInstance().current.mKeyboardHeightScale)
-        val keyHeight = defaultKeyWidth * Settings.getInstance().current.mKeyboardHeightScale
+        val defaultKeyboardHeight = ResourceUtils.getDefaultKeyboardHeight(context.resources, false)
+        val defaultBottomPadding = context.resources.getFraction(R.fraction.config_keyboard_bottom_padding_holo, defaultKeyboardHeight, defaultKeyboardHeight);
+        val emojiKeyboardHeight = ResourceUtils.getDefaultKeyboardHeight(context.resources, false) * 0.75f + params.mVerticalGap - defaultBottomPadding - context.resources.getDimensionPixelSize(R.dimen.config_emoji_category_page_id_height)
+        val keyHeight = emojiKeyboardHeight * params.mDefaultRelativeRowHeight * Settings.getInstance().current.mKeyboardHeightScale // still apply height scale to key
 
         emojiArray.forEachIndexed { i, codeArraySpec ->
             val keyParams = parseEmojiKey(codeArraySpec, moreEmojisArray?.get(i)?.takeIf { it.isNotEmpty() }) ?: return@forEachIndexed

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/KeyboardWrapperView.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/KeyboardWrapperView.kt
@@ -5,7 +5,6 @@ package org.dslul.openboard.inputmethod.latin
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
-import android.graphics.Color
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.MotionEvent
@@ -13,6 +12,7 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import org.dslul.openboard.inputmethod.keyboard.KeyboardActionListener
+import org.dslul.openboard.inputmethod.keyboard.KeyboardSwitcher
 import org.dslul.openboard.inputmethod.latin.common.ColorType
 import org.dslul.openboard.inputmethod.latin.common.Constants
 import org.dslul.openboard.inputmethod.latin.settings.Settings
@@ -29,7 +29,6 @@ class KeyboardWrapperView @JvmOverloads constructor(
 
     private lateinit var stopOneHandedModeBtn: ImageButton
     private lateinit var switchOneHandedModeBtn: ImageButton
-    private lateinit var keyboardView: View
     private lateinit var resizeOneHandedModeBtn: ImageButton
     private val iconStopOneHandedModeId: Int
     private val iconSwitchOneHandedModeId: Int
@@ -62,7 +61,6 @@ class KeyboardWrapperView @JvmOverloads constructor(
         resizeOneHandedModeBtn = findViewById(R.id.btn_resize_one_handed_mode)
         resizeOneHandedModeBtn.setImageResource(iconResizeOneHandedModeId)
         resizeOneHandedModeBtn.visibility = GONE
-        keyboardView = findViewById(R.id.keyboard_view)
 
         stopOneHandedModeBtn.setOnClickListener(this)
         switchOneHandedModeBtn.setOnClickListener(this)
@@ -141,6 +139,7 @@ class KeyboardWrapperView @JvmOverloads constructor(
 
         val isLeftGravity = oneHandedGravity == Gravity.LEFT
         val width = right - left
+        val keyboardView = KeyboardSwitcher.getInstance().visibleKeyboardView
         val spareWidth = width - keyboardView.measuredWidth
 
         val keyboardLeft = if (isLeftGravity) 0 else spareWidth

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -1248,7 +1248,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         if (mInputView == null) {
             return;
         }
-        final View visibleKeyboardView = mKeyboardSwitcher.getVisibleKeyboardView();
+        final View visibleKeyboardView = mKeyboardSwitcher.getWrapperView();
         if (visibleKeyboardView == null || !hasSuggestionStripView()) {
             return;
         }
@@ -1261,11 +1261,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
             mInsetsUpdater.setInsets(outInsets);
             return;
         }
-        final int suggestionsHeight = (!mKeyboardSwitcher.isShowingEmojiPalettes()
-                && !mKeyboardSwitcher.isShowingClipboardHistory()
-                && mSuggestionStripView.getVisibility() == View.VISIBLE)
-                ? mSuggestionStripView.getHeight() : 0;
-        final int visibleTopY = inputHeight - visibleKeyboardView.getHeight() - suggestionsHeight;
+        final int visibleTopY = inputHeight - visibleKeyboardView.getHeight() - mSuggestionStripView.getHeight();
         mSuggestionStripView.setMoreSuggestionsHeight(visibleTopY);
         // Need to set expanded touchable region only if a keyboard view is being shown.
         if (visibleKeyboardView.isShown()) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ResourceUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ResourceUtils.java
@@ -192,7 +192,7 @@ public final class ResourceUtils {
         return (int)(defaultKeyboardHeight * settingsValues.mKeyboardHeightScale);
     }
 
-    private static int getDefaultKeyboardHeight(final Resources res, final boolean showsNumberRow) {
+    public static int getDefaultKeyboardHeight(final Resources res, final boolean showsNumberRow) {
         final DisplayMetrics dm = res.getDisplayMetrics();
         final float keyboardHeight = res.getDimension(R.dimen.config_default_keyboard_height) * (showsNumberRow ? 1.25f : 1f);
         final float maxKeyboardHeight = res.getFraction(

--- a/app/src/main/res/layout/emoji_palettes_view.xml
+++ b/app/src/main/res/layout/emoji_palettes_view.xml
@@ -14,40 +14,6 @@
     android:visibility="gone"
     style="?attr/emojiPalettesViewStyle"
 >
-    <LinearLayout
-        android:id="@+id/emoji_tab_strip"
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/config_suggestions_strip_height"
-        style="?attr/suggestionStripViewStyle"
-    >
-        <org.dslul.openboard.inputmethod.compat.TabHostCompat
-            android:id="@+id/emoji_category_tabhost"
-            android:layout_width="0dip"
-            android:layout_weight="87.5"
-            android:layout_height="match_parent"
-        >
-            <TabWidget
-                android:id="@android:id/tabs"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:divider="@null" />
-            <FrameLayout
-                android:id="@android:id/tabcontent"
-                android:layout_width="0dip"
-                android:layout_height="0dip"
-            >
-                <!-- Empty placeholder that TabHost requires. But we don't use it to actually
-                     display anything. We monitor the tab changes and change the ViewPager.
-                     Similarly the ViewPager swipes are intercepted and passed to the TabHost. -->
-                <View
-                    android:id="@+id/emoji_keyboard_dummy"
-                    android:layout_width="0dip"
-                    android:layout_height="0dip"
-                    android:visibility="gone" />
-            </FrameLayout>
-        </org.dslul.openboard.inputmethod.compat.TabHostCompat>
-    </LinearLayout>
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/emoji_keyboard_list"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/input_view.xml
+++ b/app/src/main/res/layout/input_view.xml
@@ -13,10 +13,4 @@
     <include
         android:id="@+id/main_keyboard_frame"
         layout="@layout/main_keyboard_frame" />
-    <include
-        android:id="@+id/emoji_palettes_view"
-        layout="@layout/emoji_palettes_view" />
-    <include
-        android:id="@+id/clipboard_history_view"
-        layout="@layout/clipboard_history_view" />
 </org.dslul.openboard.inputmethod.latin.InputView>

--- a/app/src/main/res/layout/main_keyboard_frame.xml
+++ b/app/src/main/res/layout/main_keyboard_frame.xml
@@ -21,6 +21,40 @@
         android:layout_height="@dimen/config_suggestions_strip_height"
         android:gravity="center_vertical"
         style="?attr/suggestionStripViewStyle" />
+    <LinearLayout
+        android:id="@+id/emoji_tab_strip"
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/config_suggestions_strip_height"
+        style="?attr/suggestionStripViewStyle"
+        >
+        <org.dslul.openboard.inputmethod.compat.TabHostCompat
+            android:id="@+id/emoji_category_tabhost"
+            android:layout_width="0dip"
+            android:layout_weight="87.5"
+            android:layout_height="match_parent"
+            >
+            <TabWidget
+                android:id="@android:id/tabs"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:divider="@null" />
+            <FrameLayout
+                android:id="@android:id/tabcontent"
+                android:layout_width="0dip"
+                android:layout_height="0dip"
+                >
+                <!-- Empty placeholder that TabHost requires. But we don't use it to actually
+                     display anything. We monitor the tab changes and change the ViewPager.
+                     Similarly the ViewPager swipes are intercepted and passed to the TabHost. -->
+                <View
+                    android:id="@+id/emoji_keyboard_dummy"
+                    android:layout_width="0dip"
+                    android:layout_height="0dip"
+                    android:visibility="gone" />
+            </FrameLayout>
+        </org.dslul.openboard.inputmethod.compat.TabHostCompat>
+    </LinearLayout>
 
     <!-- To ensure that key preview popup is correctly placed when the current system locale is
          one of RTL locales, layoutDirection="ltr" is needed in the SDK version 17+. -->
@@ -35,6 +69,12 @@
             android:layoutDirection="ltr"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+        <include
+            android:id="@+id/emoji_palettes_view"
+            layout="@layout/emoji_palettes_view" />
+        <include
+            android:id="@+id/clipboard_history_view"
+            layout="@layout/clipboard_history_view" />
 
         <ImageButton
             android:id="@+id/btn_stop_one_handed_mode"

--- a/app/src/main/res/layout/main_keyboard_frame.xml
+++ b/app/src/main/res/layout/main_keyboard_frame.xml
@@ -12,49 +12,9 @@
     android:layout_gravity="bottom"
     android:orientation="vertical" >
 
-    <!-- To ensure that key preview popup is correctly placed when the current system locale is
-         one of RTL locales, layoutDirection="ltr" is needed in the SDK version 17+. -->
-    <org.dslul.openboard.inputmethod.latin.suggestions.SuggestionStripView
-        android:id="@+id/suggestion_strip_view"
-        android:layoutDirection="ltr"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/config_suggestions_strip_height"
-        android:gravity="center_vertical"
-        style="?attr/suggestionStripViewStyle" />
-    <LinearLayout
-        android:id="@+id/emoji_tab_strip"
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/config_suggestions_strip_height"
-        style="?attr/suggestionStripViewStyle"
-        >
-        <org.dslul.openboard.inputmethod.compat.TabHostCompat
-            android:id="@+id/emoji_category_tabhost"
-            android:layout_width="0dip"
-            android:layout_weight="87.5"
-            android:layout_height="match_parent"
-            >
-            <TabWidget
-                android:id="@android:id/tabs"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:divider="@null" />
-            <FrameLayout
-                android:id="@android:id/tabcontent"
-                android:layout_width="0dip"
-                android:layout_height="0dip"
-                >
-                <!-- Empty placeholder that TabHost requires. But we don't use it to actually
-                     display anything. We monitor the tab changes and change the ViewPager.
-                     Similarly the ViewPager swipes are intercepted and passed to the TabHost. -->
-                <View
-                    android:id="@+id/emoji_keyboard_dummy"
-                    android:layout_width="0dip"
-                    android:layout_height="0dip"
-                    android:visibility="gone" />
-            </FrameLayout>
-        </org.dslul.openboard.inputmethod.compat.TabHostCompat>
-    </LinearLayout>
+    <include
+        android:id="@+id/strip_container"
+        layout="@layout/strip_container" />
 
     <!-- To ensure that key preview popup is correctly placed when the current system locale is
          one of RTL locales, layoutDirection="ltr" is needed in the SDK version 17+. -->

--- a/app/src/main/res/layout/strip_container.xml
+++ b/app/src/main/res/layout/strip_container.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 The Android Open Source Project
+    modified
+    SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-only
+-->
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/config_suggestions_strip_height">
+    <!-- To ensure that key preview popup is correctly placed when the current system locale is
+         one of RTL locales, layoutDirection="ltr" is needed in the SDK version 17+. -->
+    <org.dslul.openboard.inputmethod.latin.suggestions.SuggestionStripView
+        android:id="@+id/suggestion_strip_view"
+        android:layoutDirection="ltr"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        style="?attr/suggestionStripViewStyle" />
+    <LinearLayout
+        android:id="@+id/emoji_tab_strip"
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        style="?attr/suggestionStripViewStyle"
+        >
+        <org.dslul.openboard.inputmethod.compat.TabHostCompat
+            android:id="@+id/emoji_category_tabhost"
+            android:layout_width="0dip"
+            android:layout_weight="87.5"
+            android:layout_height="match_parent"
+            >
+            <TabWidget
+                android:id="@android:id/tabs"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:divider="@null" />
+            <FrameLayout
+                android:id="@android:id/tabcontent"
+                android:layout_width="0dip"
+                android:layout_height="0dip"
+                >
+                <!-- Empty placeholder that TabHost requires. But we don't use it to actually
+                     display anything. We monitor the tab changes and change the ViewPager.
+                     Similarly the ViewPager swipes are intercepted and passed to the TabHost. -->
+                <View
+                    android:id="@+id/emoji_keyboard_dummy"
+                    android:layout_width="0dip"
+                    android:layout_height="0dip"
+                    android:visibility="gone" />
+            </FrameLayout>
+        </org.dslul.openboard.inputmethod.compat.TabHostCompat>
+    </LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
Came up during #321, but there are still too many issues to include this in the otherwise working PR.

Maybe the whole PR will be scrapped, maybe only the second commit.
First commit makes the resize roughly work, but the suggestion strip is ignored, and the emoji tab strip appears at smaller scale below the suggestion strip. Resizing does not affect emoji keyboard internals, and always switches to main keyboard.
Second commit tries to set a combined suggestion strip / emoji tab strip, but that does not work well, the emoji tab strip still gets resized for some reason.

There are some more issues that are not mentioned here.