### PR TITLE
NDK 26.1.10909125 (r26b) requires api 21+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.dslul.openboard.inputmethod.latin"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 19
         versionName '1.4.5'


### PR DESCRIPTION
Update minSdkVersion requirements for NDK r26b

<!--
* Please bescribe briefly what your pull request proposes to fix or improve.
* If it's not completely obvious, describe what the PR does to achieve the desired result.
* If you use someone else's code, please mention or better link to the source.
-->
