### PR TITLE
Replace icons for rounded style

### DIFF
--- a/app/src/main/res/drawable/ic_arrow_horizontal_rounded.xml
+++ b/app/src/main/res/drawable/ic_arrow_horizontal_rounded.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FFF"
+      android:pathData="M273,520L308,557Q319,568 319,584.5Q319,601 308,612Q296,624 279.5,624Q263,624 252,612L148,509Q142,503 139,495.5Q136,488 136,480Q136,472 139,465Q142,458 148,452L252,348Q263,337 279.5,337Q296,337 308,348Q320,360 320,376.5Q320,393 308,405L273,440L687,440L651,404Q640,393 640,376.5Q640,360 652,348Q663,337 679.5,337Q696,337 708,348L811,452Q817,458 820,465Q823,472 823,480Q823,488 820,495.5Q817,503 811,509L707,613Q696,624 679.5,624Q663,624 651,612Q640,601 640,584.5Q640,568 651,557L687,520L273,520Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_redo_rounded.xml
+++ b/app/src/main/res/drawable/ic_redo_rounded.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FFF"
+      android:pathData="M648,400L396,400Q333,400 286.5,440Q240,480 240,540Q240,600 286.5,640Q333,680 396,680L640,680Q657,680 668.5,691.5Q680,703 680,720Q680,737 668.5,748.5Q657,760 640,760L396,760Q299,760 229.5,697Q160,634 160,540Q160,446 229.5,383Q299,320 396,320L648,320L572,244Q561,233 561,216Q561,199 572,188Q583,177 600,177Q617,177 628,188L772,332Q778,338 780.5,345Q783,352 783,360Q783,368 780.5,375Q778,382 772,388L628,532Q617,543 600,543Q583,543 572,532Q561,521 561,504Q561,487 572,476L648,400Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_undo_rounded.xml
+++ b/app/src/main/res/drawable/ic_undo_rounded.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FFF"
+      android:pathData="M320,760Q303,760 291.5,748.5Q280,737 280,720Q280,703 291.5,691.5Q303,680 320,680L564,680Q627,680 673.5,640Q720,600 720,540Q720,480 673.5,440Q627,400 564,400L312,400L388,476Q399,487 399,504Q399,521 388,532Q377,543 360,543Q343,543 332,532L188,388Q182,382 179.5,375Q177,368 177,360Q177,352 179.5,345Q182,338 188,332L332,188Q343,177 360,177Q377,177 388,188Q399,199 399,216Q399,233 388,244L312,320L564,320Q661,320 730.5,383Q800,446 800,540Q800,634 730.5,697Q661,760 564,760L320,760Z"/>
+</vector>

--- a/app/src/main/res/values/keyboard-icons-rounded.xml
+++ b/app/src/main/res/values/keyboard-icons-rounded.xml
@@ -36,7 +36,7 @@
         <item name="iconStartOneHandedMode">@drawable/sym_keyboard_start_onehanded_rounded</item>
         <item name="iconStopOneHandedMode">@drawable/sym_keyboard_stop_onehanded_rounded</item>
         <item name="iconSwitchOneHandedMode">@drawable/ic_arrow_left_rounded</item>
-        <item name="iconResizeOneHandedMode">@drawable/ic_arrow_horizontal</item>
+        <item name="iconResizeOneHandedMode">@drawable/ic_arrow_horizontal_rounded</item>
         <item name="iconNumpadKey">@drawable/sym_keyboard_numpad_key_lxx</item>
         <item name="iconToolbarKey">@drawable/ic_arrow_right_rounded</item>
         <item name="iconSelectAll">@drawable/ic_select_all_rounded</item>
@@ -45,7 +45,7 @@
         <item name="iconArrowUp">@drawable/ic_arrow_up_rounded</item>
         <item name="iconArrowDown">@drawable/ic_arrow_down_rounded</item>
         <item name="iconBin">@drawable/ic_delete_rounded</item>
-        <item name="iconUndo">@drawable/ic_undo</item>
-        <item name="iconRedo">@drawable/ic_redo</item>
+        <item name="iconUndo">@drawable/ic_undo_rounded</item>
+        <item name="iconRedo">@drawable/ic_redo_rounded</item>
     </style>
 </resources>


### PR DESCRIPTION
This PR replaces the latest icons added to Openboard with new, more rounded icons.
Only the rounded style is affected, and is now more consistent.
