### PR TITLE
Remove bar under clipboard strip

### DIFF
--- a/app/src/main/res/values/themes-rounded-base-border.xml
+++ b/app/src/main/res/values/themes-rounded-base-border.xml
@@ -53,7 +53,7 @@
     <style
         name="ClipboardHistoryView.Rounded_Base_Border"
         parent="ClipboardHistoryView.Rounded_Base">
-        <item name="android:background">@drawable/keyboard_suggest_strip_lxx_base_border</item>
+        <item name="android:background">@drawable/keyboard_background_lxx_base_border</item>
         <item name="keyBackground">@drawable/btn_keyboard_key_rounded_base_border</item>
         <item name="functionalKeyBackground">@drawable/btn_keyboard_key_functional_rounded_base_border</item>
     </style>


### PR DESCRIPTION
Remove bar under clipboard strip for Rounded style:

<img width=400 src=https://github.com/Helium314/openboard/assets/139015663/7fc9da9b-1332-4f37-bcf9-397b855096e4>
