### PR TITLE
Fix the inline suggestions remaning visible when switching keyboards and fix missing toolbar

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -51,7 +51,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private View mEmojiTabStripView;
     private LinearLayout mClipboardStripView;
     private View mSuggestionStripView;
-    private View mSuggestionsView;
     private ClipboardHistoryView mClipboardHistoryView;
     private LatinIME mLatinIME;
     private RichInputMethodManager mRichImm;
@@ -283,7 +282,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mEmojiPalettesView.stopEmojiPalettes();
         mEmojiTabStripView.setVisibility(View.GONE);
         mClipboardStripView.setVisibility(View.GONE);
-        mSuggestionsView.setVisibility(View.VISIBLE);
         mSuggestionStripView.setVisibility(View.VISIBLE);
         mClipboardHistoryView.setVisibility(View.GONE);
         mClipboardHistoryView.stopClipboardHistory();
@@ -301,7 +299,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         // @see #getVisibleKeyboardView() and
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
-        mSuggestionsView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
         mClipboardStripView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.VISIBLE);
@@ -325,7 +322,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.GONE);
-        mSuggestionsView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
         mClipboardStripView.setVisibility(View.VISIBLE);
         mEmojiPalettesView.setVisibility(View.GONE);
@@ -576,7 +572,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mClipboardHistoryView.setKeyboardActionListener(mLatinIME);
         mEmojiTabStripView = mCurrentInputView.findViewById(R.id.emoji_tab_strip);
         mClipboardStripView = mCurrentInputView.findViewById(R.id.clipboard_strip);
-        mSuggestionsView = mCurrentInputView.findViewById(R.id.suggestions_strip);
         mSuggestionStripView = mCurrentInputView.findViewById(R.id.suggestion_strip_view);
         // todo: try delaying, it's not needed at this point
         //  but when initializing right before showing, selected emoji category is not colored correctly

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -51,6 +51,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private View mEmojiTabStripView;
     private LinearLayout mClipboardStripView;
     private View mSuggestionStripView;
+    private View mSuggestionsView;
     private ClipboardHistoryView mClipboardHistoryView;
     private LatinIME mLatinIME;
     private RichInputMethodManager mRichImm;
@@ -282,6 +283,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mEmojiPalettesView.stopEmojiPalettes();
         mEmojiTabStripView.setVisibility(View.GONE);
         mClipboardStripView.setVisibility(View.GONE);
+        mSuggestionsView.setVisibility(View.VISIBLE);
         mSuggestionStripView.setVisibility(View.VISIBLE);
         mClipboardHistoryView.setVisibility(View.GONE);
         mClipboardHistoryView.stopClipboardHistory();
@@ -299,6 +301,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         // @see #getVisibleKeyboardView() and
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
+        mSuggestionsView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
         mClipboardStripView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.VISIBLE);
@@ -322,6 +325,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.GONE);
+        mSuggestionsView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
         mClipboardStripView.setVisibility(View.VISIBLE);
         mEmojiPalettesView.setVisibility(View.GONE);
@@ -572,6 +576,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mClipboardHistoryView.setKeyboardActionListener(mLatinIME);
         mEmojiTabStripView = mCurrentInputView.findViewById(R.id.emoji_tab_strip);
         mClipboardStripView = mCurrentInputView.findViewById(R.id.clipboard_strip);
+        mSuggestionsView = mCurrentInputView.findViewById(R.id.suggestions_strip);
         mSuggestionStripView = mCurrentInputView.findViewById(R.id.suggestion_strip_view);
         // todo: try delaying, it's not needed at this point
         //  but when initializing right before showing, selected emoji category is not colored correctly

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
@@ -255,6 +255,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
                 : km.isKeyguardLocked();
         mToolbarExpandKey.setOnClickListener(hideToolbarKeys ? null : this);
         mPinnedKeys.setVisibility(hideToolbarKeys ? GONE : VISIBLE);
+        mToolbarExpandKey.setVisibility(VISIBLE);
     }
 
     public void setRtl(final boolean isRtlLanguage) {
@@ -298,12 +299,6 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         dismissMoreSuggestionsPanel();
         for (final TextView word : mWordViews) {
             word.setOnTouchListener(null);
-        }
-
-        // Make the tool bar and pinned keys visible if setInlineSuggestionsView() was called
-        if (mToolbarExpandKey.getVisibility() != VISIBLE) {
-            mToolbarExpandKey.setVisibility(VISIBLE);
-            mPinnedKeys.setVisibility(VISIBLE);
         }
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
@@ -65,6 +65,7 @@ import org.dslul.openboard.inputmethod.latin.utils.ToolbarUtilsKt;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.core.view.ViewCompat;
 
@@ -274,6 +275,13 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         mToolbarExpandKey.setVisibility(GONE);
         mPinnedKeys.setVisibility(GONE);
         mSuggestionsStrip.addView(view);
+    }
+
+    @Override
+    public void onVisibilityChanged(@NonNull final View view, final int visibility) {
+        super.onVisibilityChanged(view, visibility);
+        if (view == this)
+            mSuggestionsStrip.setVisibility(visibility);
     }
 
     public void setMoreSuggestionsHeight(final int remainingHeight) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
@@ -291,6 +291,10 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         for (final TextView word : mWordViews) {
             word.setOnTouchListener(null);
         }
+
+        // Make the tool bar and pinned keys visible if setInlineSuggestionsView() was called
+        mToolbarExpandKey.setVisibility(VISIBLE);
+        mPinnedKeys.setVisibility(VISIBLE);
     }
 
     private void removeAllDebugInfoViews() {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/suggestions/SuggestionStripView.java
@@ -293,8 +293,10 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         }
 
         // Make the tool bar and pinned keys visible if setInlineSuggestionsView() was called
-        mToolbarExpandKey.setVisibility(VISIBLE);
-        mPinnedKeys.setVisibility(VISIBLE);
+        if (mToolbarExpandKey.getVisibility() != VISIBLE) {
+            mToolbarExpandKey.setVisibility(VISIBLE);
+            mPinnedKeys.setVisibility(VISIBLE);
+        }
     }
 
     private void removeAllDebugInfoViews() {


### PR DESCRIPTION
This PR fixes the inline suggestions remaning visible when switching to the emoji or clipboard history keyboards. It also brings back the old changes in `clear()` as they are required to make the toolbar and pinnedkeys visible after calling `setInlineSuggestionsView()` (with a minor modification to fix the flashing pinned key bug).

I accidentally closed the last PR and I am sorry for that.