### PR TITLE
Improve inline autofill code and remove delay

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -375,6 +375,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
             removeMessages(MSG_UPDATE_SUGGESTION_STRIP);
         }
 
+        public void cancelResumeSuggestions() {
+            removeMessages(MSG_RESUME_SUGGESTIONS);
+        }
+
         public boolean hasPendingUpdateSuggestions() {
             return hasMessages(MSG_UPDATE_SUGGESTION_STRIP);
         }
@@ -1345,9 +1349,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         }
 
         final View inlineSuggestionView = InlineAutofillUtils.createView(inlineSuggestions, mDisplayContext);
-        // "normal" suggestions might be determined in parallel when processing MSG_UPDATE_SUGGESTION_STRIP
-        // so we add a delay to make sure inline suggestions are set only after normal suggestions
-        mHandler.postDelayed(() -> mSuggestionStripView.setInlineSuggestionsView(inlineSuggestionView), 200);
+
+        mHandler.cancelResumeSuggestions();
+        mHandler.cancelUpdateSuggestionStrip();
+        mSuggestionStripView.setInlineSuggestionsView(inlineSuggestionView);
 
         return true;
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/InlineAutofillUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/InlineAutofillUtils.java
@@ -6,15 +6,12 @@
 
 package org.dslul.openboard.inputmethod.latin.utils;
 
-import static android.util.TypedValue.COMPLEX_UNIT_DIP;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Size;
-import android.util.TypedValue;
 import android.view.ViewGroup;
 import android.view.inputmethod.InlineSuggestion;
 import android.view.inputmethod.InlineSuggestionsRequest;
@@ -24,10 +21,12 @@ import android.widget.inline.InlinePresentationSpec;
 
 import androidx.annotation.RequiresApi;
 import androidx.autofill.inline.UiVersions;
+import androidx.autofill.inline.UiVersions.StylesBuilder;
 import androidx.autofill.inline.common.ImageViewStyle;
 import androidx.autofill.inline.common.TextViewStyle;
 import androidx.autofill.inline.common.ViewStyle;
 import androidx.autofill.inline.v1.InlineSuggestionUi;
+import androidx.autofill.inline.v1.InlineSuggestionUi.Style;
 
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.common.ColorType;
@@ -37,25 +36,15 @@ import org.dslul.openboard.inputmethod.latin.settings.Settings;
 import java.util.ArrayList;
 import java.util.List;
 
-// Modified code from https://android.googlesource.com/platform/development/+/master/samples/AutofillKeyboard/
 @RequiresApi(api = Build.VERSION_CODES.R)
 public class InlineAutofillUtils {
-
-    private static int toPixel(int dp, Context context) {
-        return (int) TypedValue.applyDimension(COMPLEX_UNIT_DIP, dp,
-                context.getResources().getDisplayMetrics());
-    }
-
-    private static int getHeight(Context context) {
-        return context.getResources().getDimensionPixelSize(R.dimen.config_suggestions_strip_height);
-    }
 
     public static InlineSuggestionsRequest createInlineSuggestionRequest(Context context) {
 
         final Colors colors = Settings.getInstance().getCurrent().mColors;
 
-        UiVersions.StylesBuilder stylesBuilder = UiVersions.newStylesBuilder();
-        @SuppressLint("RestrictedApi") InlineSuggestionUi.Style style = InlineSuggestionUi.newStyleBuilder()
+        StylesBuilder stylesBuilder = UiVersions.newStylesBuilder();
+        @SuppressLint("RestrictedApi") Style style = InlineSuggestionUi.newStyleBuilder()
                 .setSingleIconChipStyle(
                         new ViewStyle.Builder()
                                 .setBackground(
@@ -74,24 +63,22 @@ public class InlineAutofillUtils {
                 .setStartIconStyle(new ImageViewStyle.Builder().setLayoutMargin(0, 0, 0, 0).build())
                 .setTitleStyle(
                         new TextViewStyle.Builder()
-                                .setLayoutMargin(toPixel(4, context), 0, toPixel(4, context), 0)
                                 .setTextColor(colors.get(ColorType.KEY_TEXT))
                                 .setTextSize(12)
                                 .build())
                 .setSubtitleStyle(
                         new TextViewStyle.Builder()
-                                .setLayoutMargin(0, 0, toPixel(4, context), 0)
                                 .setTextColor(colors.get(ColorType.KEY_HINT_TEXT))
                                 .setTextSize(10)
                                 .build())
                 .setEndIconStyle(new ImageViewStyle.Builder().setLayoutMargin(0, 0, 0, 0).build())
                 .build();
         stylesBuilder.addStyle(style);
-
         Bundle stylesBundle = stylesBuilder.build();
 
-        Size min = new Size(100, getHeight(context));
-        Size max = new Size(740, getHeight(context));
+        final int height = context.getResources().getDimensionPixelSize(R.dimen.config_suggestions_strip_height);
+        final Size min = new Size(100, height);
+        final Size max = new Size(740, height);
 
         final ArrayList<InlinePresentationSpec> presentationSpecs = new ArrayList<>();
         presentationSpecs.add(new InlinePresentationSpec.Builder(min, max).setStyle(stylesBundle).build());
@@ -107,7 +94,6 @@ public class InlineAutofillUtils {
 
         final int totalSuggestionsCount = inlineSuggestions.size();
 
-        // A container to hold all views
         LinearLayout container = new LinearLayout(context);
 
         for (int i = 0; i < totalSuggestionsCount; i++) {
@@ -120,13 +106,10 @@ public class InlineAutofillUtils {
             });
         }
 
-        HorizontalScrollView view = new HorizontalScrollView(context);
-        view.setLayoutParams(new ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
-        view.setHorizontalScrollBarEnabled(false);
+        HorizontalScrollView inlineSuggestionView = new HorizontalScrollView(context);
+        inlineSuggestionView.setHorizontalScrollBarEnabled(false);
+        inlineSuggestionView.addView(container);
 
-        view.addView(container);
-
-        return view;
+        return inlineSuggestionView;
     }
 }


### PR DESCRIPTION
This PR aims to cleanup the inline autofill code and remove the delay. 

After some testing I found out that canceling `MSG_RESUME_SUGGESTIONS` and `MSG_UPDATE_SUGGESTION_STRIP` made it possible for the inline autofill suggestions to appear without a delay. I made a function to cancel `MSG_RESUME_SUGGESTIONS` since there wasn't one.