### PR TITLE
Fix scrollbar overlapping icons in the toolbar container on some devices

### DIFF
--- a/app/src/main/res/layout/suggestions_strip.xml
+++ b/app/src/main/res/layout/suggestions_strip.xml
@@ -30,6 +30,7 @@
             android:id="@+id/toolbar_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:scrollbarThumbHorizontal="@color/almost_background"
             android:visibility="gone">
             <LinearLayout
                 android:id="@+id/toolbar"

--- a/app/src/main/res/layout/suggestions_strip.xml
+++ b/app/src/main/res/layout/suggestions_strip.xml
@@ -30,7 +30,7 @@
             android:id="@+id/toolbar_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scrollbarThumbHorizontal="@color/almost_background"
+            android:scrollbarThumbHorizontal="@color/toolbar_scrollbar"
             android:visibility="gone">
             <LinearLayout
                 android:id="@+id/toolbar"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -71,4 +71,7 @@
     <!-- Actually used keyboard default background colors -->
     <color name="keyboard_background_light">@color/keyboard_background_lxx_light_border</color>
     <color name="keyboard_background_dark">#263238</color>
+
+    <!-- Scrollbar color -->
+    <color name="toolbar_scrollbar">#66808080</color>
 </resources>


### PR DESCRIPTION
This PR aims to fix issue #354. 

This PR forces some devices to use the normal scrollbar with the `color/almost_background` (which looks similar to the scrollbar in pixel devices).