### PR TITLE
Improve switch alignment for layout list

### DIFF
--- a/app/src/main/res/layout/language_list_item.xml
+++ b/app/src/main/res/layout/language_list_item.xml
@@ -39,13 +39,13 @@
         android:layout_height="wrap_content" />
     <RelativeLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" >
+        android:layout_height="match_parent" >
         <Switch
             android:id="@+id/language_switch"
             android:padding="6dp"
             android:layout_gravity="center_vertical"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="match_parent" />
         <TextView
             android:id="@+id/blocker"
             android:visibility="gone"


### PR DESCRIPTION
Improve switch alignment for layout list:

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/9541d010-8e02-49fb-b442-d4029f00ae94"> | <img width=200 src="https://github.com/Helium314/openboard/assets/139015663/aa24537c-20bd-4dc1-ae98-323e0b562a40"> |