### PR TITLE
Add dynamic colors to settings

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsActivity.java
@@ -13,7 +13,7 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import org.dslul.openboard.inputmethod.latin.permissions.PermissionsManager;
-import org.dslul.openboard.inputmethod.latin.utils.ColorSettingsUtils;
+import org.dslul.openboard.inputmethod.latin.utils.ActivityThemeUtils;
 import org.dslul.openboard.inputmethod.latin.utils.NewDictionaryAdder;
 
 import androidx.annotation.NonNull;
@@ -46,7 +46,7 @@ public final class SettingsActivity extends AppCompatActivity
                     .replace(android.R.id.content, new SettingsFragment())
                     .commit();
 
-        ColorSettingsUtils.setSettingColor(this);
+        ActivityThemeUtils.setActivityTheme(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsActivity.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import org.dslul.openboard.inputmethod.latin.permissions.PermissionsManager;
+import org.dslul.openboard.inputmethod.latin.utils.ColorSettingsUtils;
 import org.dslul.openboard.inputmethod.latin.utils.NewDictionaryAdder;
 
 import androidx.annotation.NonNull;
@@ -44,6 +45,8 @@ public final class SettingsActivity extends AppCompatActivity
             getSupportFragmentManager().beginTransaction()
                     .replace(android.R.id.content, new SettingsFragment())
                     .commit();
+
+        ColorSettingsUtils.setSettingColor(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
@@ -8,46 +8,42 @@ package org.dslul.openboard.inputmethod.latin.setup;
 
 import static android.util.TypedValue.COMPLEX_UNIT_DIP;
 
-import android.app.Activity;
 import android.content.ContentResolver;
-import android.content.Context;
 import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.provider.Settings;
 import android.util.TypedValue;
 import android.view.View;
-import android.view.WindowInsetsController;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.VideoView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
-import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.settings.SettingsActivity;
+import org.dslul.openboard.inputmethod.latin.utils.ColorSettingsUtils;
 import org.dslul.openboard.inputmethod.latin.utils.JniUtils;
 import org.dslul.openboard.inputmethod.latin.utils.LeakGuardHandlerWrapper;
 import org.dslul.openboard.inputmethod.latin.utils.Log;
-import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 import org.dslul.openboard.inputmethod.latin.utils.UncachedInputMethodManagerUtils;
 
 import java.util.ArrayList;
 
 // TODO: Use Fragment to implement welcome screen and setup steps.
-public final class SetupWizardActivity extends Activity implements View.OnClickListener {
+public final class SetupWizardActivity extends AppCompatActivity implements View.OnClickListener {
     static final String TAG = SetupWizardActivity.class.getSimpleName();
 
     // For debugging purpose.
@@ -121,8 +117,11 @@ public final class SetupWizardActivity extends Activity implements View.OnClickL
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final Context context = getApplicationContext();
-        final boolean isNight = ResourceUtils.isNight(context.getResources());
+        final ActionBar actionBar = getSupportActionBar();
+        if (actionBar == null) {
+            return;
+        }
+        actionBar.hide();
 
         mImm = (InputMethodManager)getSystemService(INPUT_METHOD_SERVICE);
         mHandler = new SettingsPoolingHandler(this, mImm);
@@ -221,26 +220,7 @@ public final class SetupWizardActivity extends Activity implements View.OnClickL
         mActionFinish.setCompoundDrawablesRelativeWithIntrinsicBounds(finishDrawable, null, null, null);
         mActionFinish.setOnClickListener(this);
 
-        // Set the status bar color
-        getWindow().setStatusBarColor(getResources().getColor(R.color.setup_background));
-        // Navigation bar color
-        if (!isNight && !(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)) {
-            getWindow().setNavigationBarColor(ColorUtils.setAlphaComponent(Color.GRAY, 180));
-        } else {
-            getWindow().setNavigationBarColor(getResources().getColor(R.color.setup_background));
-        }
-        // Set the icons of the status bar and the navigation bar light or dark
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            final WindowInsetsController controller = getWindow().getInsetsController();
-            if (controller == null) return;
-            if (!isNight) {
-                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
-                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS, WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS);
-            }
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            final View view = getWindow().getDecorView();
-            view.setSystemUiVisibility(!isNight ? View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR : 0);
-        }
+        ColorSettingsUtils.setSettingColor(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
@@ -34,7 +34,7 @@ import androidx.core.graphics.drawable.DrawableCompat;
 
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.settings.SettingsActivity;
-import org.dslul.openboard.inputmethod.latin.utils.ColorSettingsUtils;
+import org.dslul.openboard.inputmethod.latin.utils.ActivityThemeUtils;
 import org.dslul.openboard.inputmethod.latin.utils.JniUtils;
 import org.dslul.openboard.inputmethod.latin.utils.LeakGuardHandlerWrapper;
 import org.dslul.openboard.inputmethod.latin.utils.Log;
@@ -220,7 +220,7 @@ public final class SetupWizardActivity extends AppCompatActivity implements View
         mActionFinish.setCompoundDrawablesRelativeWithIntrinsicBounds(finishDrawable, null, null, null);
         mActionFinish.setOnClickListener(this);
 
-        ColorSettingsUtils.setSettingColor(this);
+        ActivityThemeUtils.setActivityTheme(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
@@ -122,6 +122,7 @@ public final class SetupWizardActivity extends AppCompatActivity implements View
             return;
         }
         actionBar.hide();
+        getWindow().setStatusBarColor(getResources().getColor(R.color.setup_background));
 
         mImm = (InputMethodManager)getSystemService(INPUT_METHOD_SERVICE);
         mHandler = new SettingsPoolingHandler(this, mImm);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
@@ -123,6 +123,7 @@ public final class SetupWizardActivity extends AppCompatActivity implements View
         }
         actionBar.hide();
         getWindow().setStatusBarColor(getResources().getColor(R.color.setup_background));
+        ActivityThemeUtils.setActivityTheme(this);
 
         mImm = (InputMethodManager)getSystemService(INPUT_METHOD_SERVICE);
         mHandler = new SettingsPoolingHandler(this, mImm);
@@ -220,8 +221,6 @@ public final class SetupWizardActivity extends AppCompatActivity implements View
         DrawableCompat.setTintList(finishDrawable, step1.mTextColorStateList);
         mActionFinish.setCompoundDrawablesRelativeWithIntrinsicBounds(finishDrawable, null, null, null);
         mActionFinish.setOnClickListener(this);
-
-        ActivityThemeUtils.setActivityTheme(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsActivity.java
@@ -9,6 +9,7 @@ package org.dslul.openboard.inputmethod.latin.spellcheck;
 import android.os.Bundle;
 
 import org.dslul.openboard.inputmethod.latin.permissions.PermissionsManager;
+import org.dslul.openboard.inputmethod.latin.utils.ColorSettingsUtils;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
@@ -18,7 +19,6 @@ import androidx.core.app.ActivityCompat;
  */
 public final class SpellCheckerSettingsActivity extends AppCompatActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback {
-    private static final String DEFAULT_FRAGMENT = SpellCheckerSettingsFragment.class.getName();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -26,6 +26,8 @@ public final class SpellCheckerSettingsActivity extends AppCompatActivity
         getSupportFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new SpellCheckerSettingsFragment())
                 .commit();
+
+        ColorSettingsUtils.setSettingColor(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsActivity.java
@@ -9,7 +9,6 @@ package org.dslul.openboard.inputmethod.latin.spellcheck;
 import android.os.Bundle;
 
 import org.dslul.openboard.inputmethod.latin.permissions.PermissionsManager;
-import org.dslul.openboard.inputmethod.latin.utils.ActivityThemeUtils;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
@@ -26,8 +25,6 @@ public final class SpellCheckerSettingsActivity extends AppCompatActivity
         getSupportFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new SpellCheckerSettingsFragment())
                 .commit();
-
-        ActivityThemeUtils.setActivityTheme(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsActivity.java
@@ -9,7 +9,7 @@ package org.dslul.openboard.inputmethod.latin.spellcheck;
 import android.os.Bundle;
 
 import org.dslul.openboard.inputmethod.latin.permissions.PermissionsManager;
-import org.dslul.openboard.inputmethod.latin.utils.ColorSettingsUtils;
+import org.dslul.openboard.inputmethod.latin.utils.ActivityThemeUtils;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
@@ -27,7 +27,7 @@ public final class SpellCheckerSettingsActivity extends AppCompatActivity
                 .replace(android.R.id.content, new SpellCheckerSettingsFragment())
                 .commit();
 
-        ColorSettingsUtils.setSettingColor(this);
+        ActivityThemeUtils.setActivityTheme(this);
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsFragment.java
@@ -15,6 +15,7 @@ import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.permissions.PermissionsManager;
 import org.dslul.openboard.inputmethod.latin.permissions.PermissionsUtil;
 import org.dslul.openboard.inputmethod.latin.settings.SubScreenFragment;
+import org.dslul.openboard.inputmethod.latin.utils.ActivityThemeUtils;
 
 import androidx.preference.SwitchPreferenceCompat;
 
@@ -31,8 +32,10 @@ public final class SpellCheckerSettingsFragment extends SubScreenFragment
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.spell_checker_settings);
-        mLookupContactsPreference = (SwitchPreferenceCompat) findPreference(AndroidSpellCheckerService.PREF_USE_CONTACTS_KEY);
+        mLookupContactsPreference = findPreference(AndroidSpellCheckerService.PREF_USE_CONTACTS_KEY);
         turnOffLookupContactsIfNoPermission();
+
+        ActivityThemeUtils.setFragmentTheme(requireActivity());
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/SpellCheckerSettingsFragment.java
@@ -35,7 +35,7 @@ public final class SpellCheckerSettingsFragment extends SubScreenFragment
         mLookupContactsPreference = findPreference(AndroidSpellCheckerService.PREF_USE_CONTACTS_KEY);
         turnOffLookupContactsIfNoPermission();
 
-        ActivityThemeUtils.setFragmentTheme(requireActivity());
+        ActivityThemeUtils.setActivityTheme(requireActivity());
     }
 
     @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
@@ -5,17 +5,30 @@ import android.os.Build;
 import android.view.View;
 import android.view.WindowInsetsController;
 
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 
 public class ActivityThemeUtils {
 
     public static void setActivityTheme(final AppCompatActivity activity) {
         final boolean isNight = ResourceUtils.isNight(activity.getResources());
-        final ActionBar actionBar = activity.getSupportActionBar();
-        if (actionBar == null) {
-            return;
+
+        // Set the icons of the status bar and the navigation bar light or dark
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            final WindowInsetsController controller = activity.getWindow().getInsetsController();
+            if (controller != null && !isNight) {
+                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS, WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS);
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            final View view = activity.getWindow().getDecorView();
+            view.setSystemUiVisibility(!isNight ? View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR : 0);
         }
+    }
+
+
+    public static void setFragmentTheme(final FragmentActivity activity) {
+        final boolean isNight = ResourceUtils.isNight(activity.getResources());
 
         // Set the icons of the status bar and the navigation bar light or dark
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
@@ -7,18 +7,10 @@ import android.view.WindowInsetsController;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import org.dslul.openboard.inputmethod.latin.R;
-import org.dslul.openboard.inputmethod.latin.setup.SetupWizardActivity;
-
 public class ActivityThemeUtils {
 
     public static void setActivityTheme(final AppCompatActivity activity) {
         final boolean isNight = ResourceUtils.isNight(activity.getResources());
-
-        // Set status bar color only in install views
-        if (activity instanceof SetupWizardActivity) {
-            activity.getWindow().setStatusBarColor(activity.getResources().getColor(R.color.setup_background));
-        }
 
         // Set the icons of the status bar and the navigation bar light or dark
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
@@ -15,9 +15,9 @@ import androidx.core.graphics.ColorUtils;
 
 import org.dslul.openboard.inputmethod.latin.R;
 
-public class ColorSettingsUtils {
+public class ActivityThemeUtils {
 
-    public static void setSettingColor(final AppCompatActivity activity) {
+    public static void setActivityTheme(final AppCompatActivity activity) {
         final ActionBar actionBar = activity.getSupportActionBar();
         final boolean isNight = ResourceUtils.isNight(activity.getResources());
         final ColorDrawable actionBarColor = new ColorDrawable(ContextCompat.getColor(activity, R.color.action_bar_color));

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
@@ -1,33 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package org.dslul.openboard.inputmethod.latin.utils;
 
+import android.app.Activity;
 import android.os.Build;
 import android.view.View;
 import android.view.WindowInsetsController;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.FragmentActivity;
-
 public class ActivityThemeUtils {
 
-    public static void setActivityTheme(final AppCompatActivity activity) {
-        final boolean isNight = ResourceUtils.isNight(activity.getResources());
-
-        // Set the icons of the status bar and the navigation bar light or dark
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            final WindowInsetsController controller = activity.getWindow().getInsetsController();
-            if (controller != null && !isNight) {
-                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
-                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS, WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS);
-            }
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            final View view = activity.getWindow().getDecorView();
-            view.setSystemUiVisibility(!isNight ? View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR : 0);
-        }
-    }
-
-
-    public static void setFragmentTheme(final FragmentActivity activity) {
+    public static void setActivityTheme(final Activity activity) {
         final boolean isNight = ResourceUtils.isNight(activity.getResources());
 
         // Set the icons of the status bar and the navigation bar light or dark

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
@@ -5,12 +5,17 @@ import android.os.Build;
 import android.view.View;
 import android.view.WindowInsetsController;
 
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class ActivityThemeUtils {
 
     public static void setActivityTheme(final AppCompatActivity activity) {
         final boolean isNight = ResourceUtils.isNight(activity.getResources());
+        final ActionBar actionBar = activity.getSupportActionBar();
+        if (actionBar == null) {
+            return;
+        }
 
         // Set the icons of the status bar and the navigation bar light or dark
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ActivityThemeUtils.java
@@ -1,47 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package org.dslul.openboard.inputmethod.latin.utils;
 
-import android.graphics.Color;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.view.View;
 import android.view.WindowInsetsController;
 
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
-import androidx.core.graphics.ColorUtils;
 
 import org.dslul.openboard.inputmethod.latin.R;
+import org.dslul.openboard.inputmethod.latin.setup.SetupWizardActivity;
 
 public class ActivityThemeUtils {
 
     public static void setActivityTheme(final AppCompatActivity activity) {
-        final ActionBar actionBar = activity.getSupportActionBar();
         final boolean isNight = ResourceUtils.isNight(activity.getResources());
-        final ColorDrawable actionBarColor = new ColorDrawable(ContextCompat.getColor(activity, R.color.action_bar_color));
-        final int backgroundColor = ContextCompat.getColor(activity, R.color.setup_background);
 
-        if (actionBar == null) {
-            return;
-        }
-        actionBar.setBackgroundDrawable(actionBarColor);
-        // Settings background color
-        activity.getWindow().getDecorView().getBackground().setColorFilter(backgroundColor, PorterDuff.Mode.SRC);
-
-        // Set the status bar color
-        if (actionBar.isShowing()) {
-            activity.getWindow().setStatusBarColor(actionBarColor.getColor());
-        } else {
-            activity.getWindow().setStatusBarColor(backgroundColor);
-        }
-
-        // Navigation bar colors
-        if (!isNight && !(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)) {
-            activity.getWindow().setNavigationBarColor(ColorUtils.setAlphaComponent(Color.GRAY, 180));
-        } else {
-            activity.getWindow().setNavigationBarColor(backgroundColor);
+        // Set status bar color only in install views
+        if (activity instanceof SetupWizardActivity) {
+            activity.getWindow().setStatusBarColor(activity.getResources().getColor(R.color.setup_background));
         }
 
         // Set the icons of the status bar and the navigation bar light or dark

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ColorSettingsUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ColorSettingsUtils.java
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package org.dslul.openboard.inputmethod.latin.utils;
+
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
+import android.view.View;
+import android.view.WindowInsetsController;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.ColorUtils;
+
+import org.dslul.openboard.inputmethod.latin.R;
+
+public class ColorSettingsUtils {
+
+    public static void setSettingColor(final AppCompatActivity activity) {
+        final ActionBar actionBar = activity.getSupportActionBar();
+        final boolean isNight = ResourceUtils.isNight(activity.getResources());
+        final ColorDrawable actionBarColor = new ColorDrawable(ContextCompat.getColor(activity, R.color.action_bar_color));
+        final int backgroundColor = ContextCompat.getColor(activity, R.color.setup_background);
+
+        if (actionBar == null) {
+            return;
+        }
+        actionBar.setBackgroundDrawable(actionBarColor);
+        // Settings background color
+        activity.getWindow().getDecorView().getBackground().setColorFilter(backgroundColor, PorterDuff.Mode.SRC);
+
+        // Set the status bar color
+        if (actionBar.isShowing()) {
+            activity.getWindow().setStatusBarColor(actionBarColor.getColor());
+        } else {
+            activity.getWindow().setStatusBarColor(backgroundColor);
+        }
+
+        // Navigation bar colors
+        if (!isNight && !(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)) {
+            activity.getWindow().setNavigationBarColor(ColorUtils.setAlphaComponent(Color.GRAY, 180));
+        } else {
+            activity.getWindow().setNavigationBarColor(backgroundColor);
+        }
+
+        // Set the icons of the status bar and the navigation bar light or dark
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            final WindowInsetsController controller = activity.getWindow().getInsetsController();
+            if (controller != null && !isNight) {
+                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS, WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS);
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            final View view = activity.getWindow().getDecorView();
+            view.setSystemUiVisibility(!isNight ? View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR : 0);
+        }
+    }
+
+}

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/MoreKeysUtils.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/MoreKeysUtils.kt
@@ -121,9 +121,7 @@ fun reorderMoreKeysDialog(context: Context, key: String, defaultSetting: String,
         override fun areItemsTheSame(p0: Pair<String, Boolean>, p1: Pair<String, Boolean>) = p0 == p1
         override fun areContentsTheSame(p0: Pair<String, Boolean>, p1: Pair<String, Boolean>) = p0 == p1
     }
-    val bgColor = if (ResourceUtils.isNight(context.resources))
-            ContextCompat.getColor(context, androidx.appcompat.R.color.background_floating_material_dark)
-        else ContextCompat.getColor(context, androidx.appcompat.R.color.background_floating_material_light)
+    val bgColor = ContextCompat.getColor(context, R.color.sliding_items_background)
     val adapter = object : ListAdapter<Pair<String, Boolean>, RecyclerView.ViewHolder>(callback) {
         override fun onCreateViewHolder(p0: ViewGroup, p1: Int): RecyclerView.ViewHolder {
             val b = LayoutInflater.from(context).inflate(R.layout.morekeys_list_item, rv, false)

--- a/app/src/main/res/layout/seek_bar_dialog.xml
+++ b/app/src/main/res/layout/seek_bar_dialog.xml
@@ -19,7 +19,7 @@
         <TextView android:id="@+id/seek_bar_dialog_value"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="20sp"/>
+            android:textSize="18sp"/>
     </LinearLayout>
     <SeekBar
         android:id="@+id/seek_bar_dialog_bar"

--- a/app/src/main/res/layout/seek_bar_dialog.xml
+++ b/app/src/main/res/layout/seek_bar_dialog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (C) 2012 The Android Open Source Project
+    modified
     SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/app/src/main/res/layout/user_dictionary_add_word_fullscreen.xml
+++ b/app/src/main/res/layout/user_dictionary_add_word_fullscreen.xml
@@ -113,8 +113,8 @@
         android:baselineAligned="false">
 
         <Button
-            style="@style/Widget.AppCompat.Button.Colored"
             android:id="@+id/user_dictionary_delete_button"
+            android:backgroundTint="@color/accent"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -124,8 +124,8 @@
         </Button>
 
         <Button
-            style="@style/Widget.AppCompat.Button.Colored"
             android:id="@+id/user_dictionary_save_button"
+            android:backgroundTint="@color/accent"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"

--- a/app/src/main/res/layout/user_dictionary_settings_list_fragment.xml
+++ b/app/src/main/res/layout/user_dictionary_settings_list_fragment.xml
@@ -39,8 +39,8 @@
         android:gravity="bottom|end"
         android:background="@android:color/transparent">
         <Button
-            style="@style/Widget.AppCompat.Button.Colored"
             android:id="@+id/user_dictionary_add_word_button"
+            android:backgroundTint="@color/accent"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/user_dict_add_word_button"

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -14,5 +14,5 @@
     <color name="action_bar_color">@android:color/system_neutral2_800</color>
     <color name="sliding_items_background">@android:color/system_neutral2_800</color>
     <color name="dialog_background">@android:color/system_neutral2_800</color>
-    <color name="drop_down_menu_background">@android:color/system_neutral2_800</color>
+    <color name="drop_down_menu_background">@android:color/system_neutral2_700</color>
 </resources>

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -3,13 +3,16 @@
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <resources>
+    <!-- Color resources for setup wizard, tutorial and settings -->
     <color name="accent">@android:color/system_accent1_500</color>
-
-    <!-- Color resources for setup wizard and tutorial -->
     <color name="setup_background">@android:color/system_neutral1_900</color>
     <color name="setup_step_background">@android:color/system_accent1_500</color>
     <color name="setup_step_action_pressed">@android:color/system_accent1_700</color>
     <color name="setup_text_title">@android:color/system_accent1_300</color>
     <color name="setup_text_action">#FFFFFFFF</color>
     <color name="setup_step_action_text_pressed">@android:color/system_accent1_500</color>
+    <color name="action_bar_color">@android:color/system_neutral2_800</color>
+    <color name="sliding_items_background">@android:color/system_neutral2_800</color>
+    <color name="dialog_background">@android:color/system_neutral2_800</color>
+    <color name="drop_down_menu_background">@android:color/system_neutral2_800</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -10,7 +10,7 @@
     <color name="accent">@color/highlight_color_lxx_dark</color>
     <color name="keyboard_background">@color/keyboard_background_dark</color>
 
-    <!-- Color resources for setup wizard and tutorial -->
+    <!-- Color resources for setup wizard, tutorial and settings -->
     <color name="setup_background">#FF303030</color>
     <color name="setup_step_background">#FF2D4260</color>
     <color name="setup_step_action_pressed">#FF314868</color>
@@ -18,4 +18,6 @@
     <color name="setup_text_action">#FFFFFFFF</color>
     <color name="setup_step_action_text_pressed">#FF5E9CED</color>
     <color name="setup_welcome_video_margin_color">#FFCCCCCC</color>
+    <color name="action_bar_color">#FF212121</color>
+    <color name="sliding_items_background">#FF424242</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -7,10 +7,10 @@
     <color name="foreground_weak">#BBB</color>
     <color name="almost_background">#666</color>
 
-    <color name="accent">@color/highlight_color_lxx_dark</color>
     <color name="keyboard_background">@color/keyboard_background_dark</color>
 
     <!-- Color resources for setup wizard, tutorial and settings -->
+    <color name="accent">@color/highlight_color_lxx_dark</color>
     <color name="setup_background">#FF303030</color>
     <color name="setup_step_background">#FF2D4260</color>
     <color name="setup_step_action_pressed">#FF314868</color>
@@ -19,5 +19,6 @@
     <color name="setup_step_action_text_pressed">#FF5E9CED</color>
     <color name="setup_welcome_video_margin_color">#FFCCCCCC</color>
     <color name="action_bar_color">#FF212121</color>
+    <color name="navigation_bar_color">#FF303030</color>
     <color name="sliding_items_background">#FF424242</color>
 </resources>

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -15,11 +15,16 @@
     <color name="keyboard_background_light">@android:color/system_neutral1_100</color>
     <color name="keyboard_background_dark">@android:color/system_neutral1_800</color>
 
-    <!-- Color resources for setup wizard and tutorial -->
+    <!-- Color resources for setup wizard, tutorial and settings -->
+    <color name="accent">@android:color/system_accent1_600</color>
     <color name="setup_background">@android:color/system_neutral1_10</color>
     <color name="setup_step_background">@android:color/system_accent1_50</color>
     <color name="setup_step_action_pressed">@android:color/system_accent1_100</color>
     <color name="setup_text_title">@android:color/system_accent1_700</color>
     <color name="setup_text_action">@android:color/system_accent1_700</color>
     <color name="setup_step_action_text_pressed">@android:color/system_accent1_500</color>
+    <color name="action_bar_color">@android:color/system_accent1_50</color>
+    <color name="sliding_items_background">@android:color/system_accent1_50</color>
+    <color name="dialog_background">@android:color/system_accent1_50</color>
+    <color name="drop_down_menu_background">@android:color/system_accent1_10</color>
 </resources>

--- a/app/src/main/res/values-v31/platform-theme.xml
+++ b/app/src/main/res/values-v31/platform-theme.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="platformActivityTheme" parent="Theme.AppCompat.DayNight">
+        <item name="android:colorAccent">@color/accent</item>
+        <item name="colorAccent">@color/accent</item>
+
+        <item name="android:actionBarSize">80dp</item>
+        <item name="actionBarSize">80dp</item>
+
+        <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
+        <item name="alertDialogTheme">@style/AlertDialogTheme</item>
+
+        <item name="android:buttonCornerRadius">50dp</item>
+
+        <item name="android:spinnerDropDownItemStyle">@style/DropDownMenuTheme</item>
+        <item name="spinnerDropDownItemStyle">@style/DropDownMenuTheme</item>
+
+        <item name="android:actionBarPopupTheme">@style/MenuTheme</item>
+        <item name="actionBarPopupTheme">@style/MenuTheme</item>
+
+    </style>
+
+    <style name="AlertDialogTheme" parent="ThemeOverlay.AppCompat.Dialog.Alert">
+        <item name="android:background">@color/dialog_background</item>
+        <item name="background">@color/dialog_background</item>
+        <item name="android:dialogCornerRadius">28dp</item>
+        <item name="dialogCornerRadius">28dp</item>
+    </style>
+
+    <style name="DropDownMenuTheme" parent="Widget.AppCompat.DropDownItem.Spinner">
+        <item name="android:background">@color/drop_down_menu_background</item>
+        <item name="background">@color/drop_down_menu_background</item>
+    </style>
+
+    <style name="MenuTheme" parent="ThemeOverlay.AppCompat.ActionBar">
+        <item name="android:background">@color/drop_down_menu_background</item>
+        <item name="background">@color/drop_down_menu_background</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values-v31/platform-theme.xml
+++ b/app/src/main/res/values-v31/platform-theme.xml
@@ -25,7 +25,6 @@
         <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="alertDialogTheme">@style/AlertDialogTheme</item>
 
-        <!-- Todo: Fix the ripple effect caused by corner radius -->
         <item name="android:buttonCornerRadius">50dp</item>
 
         <item name="android:spinnerDropDownItemStyle">@style/DropDownMenuTheme</item>

--- a/app/src/main/res/values-v31/platform-theme.xml
+++ b/app/src/main/res/values-v31/platform-theme.xml
@@ -6,22 +6,38 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="platformActivityTheme" parent="Theme.AppCompat.DayNight">
+    <!-- Some items are duplicated from the original platform-theme file to ensure that the
+         "android/system_accent_*" or "android/system_neutral_*" colors are used. -->
+
         <item name="android:colorAccent">@color/accent</item>
         <item name="colorAccent">@color/accent</item>
 
+        <item name="android:statusBarColor">@color/action_bar_color</item>
+        <item name="android:navigationBarColor">@color/setup_background</item>
+
+        <item name="actionBarStyle">@style/ActionBarStyle</item>
         <item name="android:actionBarSize">80dp</item>
         <item name="actionBarSize">80dp</item>
+
+        <!-- Preference list background color -->
+        <item name="android:windowBackground">@color/setup_background</item>
 
         <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="alertDialogTheme">@style/AlertDialogTheme</item>
 
+        <!-- Todo: Fix the ripple effect caused by corner radius -->
         <item name="android:buttonCornerRadius">50dp</item>
 
         <item name="android:spinnerDropDownItemStyle">@style/DropDownMenuTheme</item>
         <item name="spinnerDropDownItemStyle">@style/DropDownMenuTheme</item>
-        <!-- To change the background of options menu -->
-        <item name="android:itemBackground">@color/drop_down_menu_background</item>
 
+        <!-- Menu background -->
+        <item name="android:itemBackground">@color/drop_down_menu_background</item>
+    </style>
+
+    <style name="ActionBarStyle" parent="Widget.AppCompat.ActionBar">
+        <item name="android:background">@color/action_bar_color</item>*
+        <item name="background">@color/action_bar_color</item>
     </style>
 
     <style name="AlertDialogTheme" parent="ThemeOverlay.AppCompat.Dialog.Alert">

--- a/app/src/main/res/values-v31/platform-theme.xml
+++ b/app/src/main/res/values-v31/platform-theme.xml
@@ -19,9 +19,8 @@
 
         <item name="android:spinnerDropDownItemStyle">@style/DropDownMenuTheme</item>
         <item name="spinnerDropDownItemStyle">@style/DropDownMenuTheme</item>
-
-        <item name="android:actionBarPopupTheme">@style/MenuTheme</item>
-        <item name="actionBarPopupTheme">@style/MenuTheme</item>
+        <!-- To change the background of options menu -->
+        <item name="android:itemBackground">@color/drop_down_menu_background</item>
 
     </style>
 
@@ -33,11 +32,6 @@
     </style>
 
     <style name="DropDownMenuTheme" parent="Widget.AppCompat.DropDownItem.Spinner">
-        <item name="android:background">@color/drop_down_menu_background</item>
-        <item name="background">@color/drop_down_menu_background</item>
-    </style>
-
-    <style name="MenuTheme" parent="ThemeOverlay.AppCompat.ActionBar">
         <item name="android:background">@color/drop_down_menu_background</item>
         <item name="background">@color/drop_down_menu_background</item>
     </style>

--- a/app/src/main/res/values-v31/platform-theme.xml
+++ b/app/src/main/res/values-v31/platform-theme.xml
@@ -25,8 +25,8 @@
     </style>
 
     <style name="AlertDialogTheme" parent="ThemeOverlay.AppCompat.Dialog.Alert">
-        <item name="android:background">@color/dialog_background</item>
-        <item name="background">@color/dialog_background</item>
+        <item name="android:colorBackgroundFloating">@color/dialog_background</item>
+        <item name="colorBackgroundFloating">@color/dialog_background</item>
         <item name="android:dialogCornerRadius">28dp</item>
         <item name="dialogCornerRadius">28dp</item>
     </style>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -52,7 +52,7 @@
     <color name="key_bottom_bevel_lxx_base">#A9ABAD</color>
     <color name="emoji_tab_page_indicator_background_lxx_base_border">@android:color/white</color>
 
-    <!-- Color resources for setup wizard and tutorial -->
+    <!-- Color resources for setup wizard, tutorial and settings -->
     <color name="setup_background">#FFFAFAFA</color>
     <color name="setup_step_background">#FFD1E3FA</color>
     <color name="setup_step_action_pressed">#FFE8F1FC</color>
@@ -60,6 +60,8 @@
     <color name="setup_text_action">#FF1767CF</color>
     <color name="setup_step_action_text_pressed">#FF5E9CED</color>
     <color name="setup_welcome_video_margin_color">#FFCCCCCC</color>
+    <color name="action_bar_color">#FFF5F5F5</color>
+    <color name="sliding_items_background">#FFFFFFFF</color>
 
     <!-- Colors that are different for night theme -->
     <color name="foreground">#000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -53,6 +53,7 @@
     <color name="emoji_tab_page_indicator_background_lxx_base_border">@android:color/white</color>
 
     <!-- Color resources for setup wizard, tutorial and settings -->
+    <color name="accent">@color/highlight_color_lxx_light</color>
     <color name="setup_background">#FFFAFAFA</color>
     <color name="setup_step_background">#FFD1E3FA</color>
     <color name="setup_step_action_pressed">#FFE8F1FC</color>
@@ -61,6 +62,7 @@
     <color name="setup_step_action_text_pressed">#FF5E9CED</color>
     <color name="setup_welcome_video_margin_color">#FFCCCCCC</color>
     <color name="action_bar_color">#FFF5F5F5</color>
+    <color name="navigation_bar_color">#B3888888</color>
     <color name="sliding_items_background">#FFFFFFFF</color>
 
     <!-- Colors that are different for night theme -->
@@ -68,7 +70,6 @@
     <color name="foreground_weak">#555</color>
     <color name="almost_background">#AAA</color>
     <color name="highlight_color_lxx_light">#1A73E8</color> <!-- todo: remove / replace with accent? -->
-    <color name="accent">@color/highlight_color_lxx_light</color>
     <color name="keyboard_background">@color/keyboard_background_light</color>
 
     <!-- Actually used keyboard default background colors -->

--- a/app/src/main/res/values/platform-theme.xml
+++ b/app/src/main/res/values/platform-theme.xml
@@ -9,5 +9,8 @@
     <style name="platformActivityTheme" parent="Theme.AppCompat.DayNight">
         <item name="android:colorAccent">@color/accent</item>
         <item name="colorAccent">@color/accent</item>
+
+        <item name="android:statusBarColor">@color/action_bar_color</item>
+        <item name="android:navigationBarColor">@color/navigation_bar_color</item>
     </style>
 </resources>


### PR DESCRIPTION
As mentioned [here](https://github.com/Helium314/openboard/pull/447#issue-2099413173), the aim of this PR is to add dynamic colors to Openboard settings.

For Android12+, I tried to copy the material design as best I could without adding a new dependency (the dialog boxes are rounder and the colors are really almost the same).

Finally, as in #447, the colors of the status and navigation bars have been modified to be more modern.

<details>
<summary><b>See screenshots</b></summary>
<br>

|       | Before | After (Android 13) |
| :--: | :------: | :-------------------: |
| Day Mode | <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/bebfa9f2-0328-4b18-8c8a-0e56835db4a0"> <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/ad8b74d3-d4a5-4c36-8a19-7563cf7280a3"> | <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/d32ce8bc-d02d-4b7e-8bbf-ee904f628c58"> <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/cadd13b5-797d-4122-8783-50df9f78eefd"> |
| Night Mode | <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/05758e17-111e-41a8-b4b0-ebdcb5a3b858"> <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/e4a95138-52a3-4434-a37f-d7911209d405"> | <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/58a1f7c1-3980-410a-b877-4b8d810909c1"> <img width=150 src="https://github.com/Helium314/openboard/assets/139015663/d90ad94c-8342-46cd-b7ba-1c75f8c5083c"> |

</details>

_Tested with Android 9 / 12 / 13_
