### PR TITLE
Introducing Kabyle layout.

### DIFF
--- a/app/src/main/assets/language_key_texts/kab.txt
+++ b/app/src/main/assets/language_key_texts/kab.txt
@@ -1,0 +1,16 @@
+[morekeys]
+a ɛ
+z ẓ
+r ṛ
+t ṭ
+u o
+s ṣ
+d ḍ
+g ǧ
+h ḥ
+c č
+b p
+
+[labels]
+alphabet: AƐΓ
+

--- a/app/src/main/assets/layouts/kabyle.json
+++ b/app/src/main/assets/layouts/kabyle.json
@@ -1,0 +1,38 @@
+[
+  [
+    { "label": "a" },
+    { "label": "z" },
+    { "label": "e" },
+    { "label": "r" },
+    { "label": "t" },
+    { "label": "y" },
+    { "label": "u" },
+    { "label": "i" },
+    { "label": "ɛ" },
+    { "label": "ɣ" }
+  ],
+  [
+    { "label": "q" },
+    { "label": "s" },
+    { "label": "d" },
+    { "label": "f" },
+    { "label": "g" },
+    { "label": "h" },
+    { "label": "j" },
+    { "label": "k" },
+    { "label": "l" },
+    { "label": "m", "popup": { "main": { "label": "/" } } }
+  ],
+  [
+    { "label": "w" },
+    { "label": "x" },
+    { "label": "c" },
+    { "label": "v" },
+    { "label": "b" },
+    { "label": "n" },
+    { "$": "shift_state_selector",
+      "shiftedManual": { "label": "?" },
+      "default": { "label": "'" }
+    }
+  ]
+]

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -58,6 +58,7 @@
     it_CH: Italian (Switzerland)/qwertz+
     iw: Hebrew/hebrew        # "he" is the official language code of Hebrew.
     ka_GE: Georgian (Georgia)/georgian
+    kab: Kabyle (Algeria)/azerty # This is a preliminary keyboard layout.
     kk: Kazakh/ru
     km_KH: Khmer (Cambodia)/khmer
     kn_IN: Kannada (India)/kannada
@@ -532,6 +533,15 @@
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=hebrew,SupportTouchPositionCorrection,EmojiCapable"
             android:isAsciiCapable="false"
+    />
+    <subtype android:icon="@drawable/ic_ime_switcher"
+            android:label="@string/subtype_generic"
+            android:subtypeId="0x2d5e7a1f"
+            android:imeSubtypeLocale="kab"
+            android:languageTag="kab"
+            android:imeSubtypeMode="keyboard"
+            android:imeSubtypeExtraValue="KeyboardLayoutSet=kabyle,AsciiCapable,SupportTouchPositionCorrection,EmojiCapable"
+            android:isAsciiCapable="true"
     />
     <subtype android:icon="@drawable/ic_ime_switcher"
             android:label="@string/subtype_generic"


### PR DESCRIPTION
Hi,

I'm introducing `kabyle layout` as mentioned in this issue https://github.com/Helium314/openboard/issues/450 . I'm not sure about the `android:subtypeId="0x00000000"` so, the file `method.xml` is not included in this PR neither the dictionary. I'll work on it on the next PR.

Kabyle written natively is `Taqbaylit`, this is for AZERTY.

Feel free to comment.