### PR TITLE
Fix "For all languages" display

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/settings/UserDictionarySettings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/UserDictionarySettings.java
@@ -217,13 +217,14 @@ public class UserDictionarySettings extends ListFragment {
      */
     private void showAddOrEditFragment(final String editingWord, final String editingShortcut, final String editingWeight) {
         final Bundle args = new Bundle();
+        final String localeString = mLocale.equals(emptyLocale) ? emptyLocale.toString() : mLocale.toLanguageTag();
         args.putInt(UserDictionaryAddWordContents.EXTRA_MODE, null == editingWord
                 ? UserDictionaryAddWordContents.MODE_INSERT
                 : UserDictionaryAddWordContents.MODE_EDIT);
         args.putString(UserDictionaryAddWordContents.EXTRA_WORD, editingWord);
         args.putString(UserDictionaryAddWordContents.EXTRA_SHORTCUT, editingShortcut);
         args.putString(UserDictionaryAddWordContents.EXTRA_WEIGHT, editingWeight);
-        args.putString(UserDictionaryAddWordContents.EXTRA_LOCALE, mLocale.toLanguageTag());
+        args.putString(UserDictionaryAddWordContents.EXTRA_LOCALE, localeString);
         AppCompatActivity activity = (AppCompatActivity) requireActivity();
         activity.getSupportFragmentManager().beginTransaction()
                 .replace(android.R.id.content, UserDictionaryAddWordFragment.class, args)

--- a/app/src/main/java/helium314/keyboard/latin/settings/UserDictionarySettings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/UserDictionarySettings.java
@@ -217,14 +217,13 @@ public class UserDictionarySettings extends ListFragment {
      */
     private void showAddOrEditFragment(final String editingWord, final String editingShortcut, final String editingWeight) {
         final Bundle args = new Bundle();
-        final String localeString = mLocale.equals(emptyLocale) ? emptyLocale.toString() : mLocale.toLanguageTag();
         args.putInt(UserDictionaryAddWordContents.EXTRA_MODE, null == editingWord
                 ? UserDictionaryAddWordContents.MODE_INSERT
                 : UserDictionaryAddWordContents.MODE_EDIT);
         args.putString(UserDictionaryAddWordContents.EXTRA_WORD, editingWord);
         args.putString(UserDictionaryAddWordContents.EXTRA_SHORTCUT, editingShortcut);
         args.putString(UserDictionaryAddWordContents.EXTRA_WEIGHT, editingWeight);
-        args.putString(UserDictionaryAddWordContents.EXTRA_LOCALE, localeString);
+        args.putString(UserDictionaryAddWordContents.EXTRA_LOCALE, mLocale.equals(emptyLocale) ? "" : mLocale.toLanguageTag());
         AppCompatActivity activity = (AppCompatActivity) requireActivity();
         activity.getSupportFragmentManager().beginTransaction()
                 .replace(android.R.id.content, UserDictionaryAddWordFragment.class, args)


### PR DESCRIPTION
As discussed [here](https://github.com/Helium314/openboard/pull/445#issuecomment-1922354198), the display of "For all languages" is now fixed.

_Tested with Android 9, 12 & 13_
